### PR TITLE
Enable right arrow to advance after grading

### DIFF
--- a/yap-frontend/src/components/challenges/TranscriptionChallenge.tsx
+++ b/yap-frontend/src/components/challenges/TranscriptionChallenge.tsx
@@ -147,10 +147,10 @@ export function TranscriptionChallenge({
   // Global keyboard handler for Enter key
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Enter') {
-        const activeElement = document.activeElement
-        const isInputFocused = activeElement?.tagName === 'INPUT'
+      const activeElement = document.activeElement
+      const isInputFocused = activeElement?.tagName === 'INPUT'
 
+      if (e.key === 'Enter') {
         if (isInputFocused) {
           // Handle input navigation
           e.preventDefault()
@@ -175,6 +175,9 @@ export function TranscriptionChallenge({
           e.preventDefault()
           onComplete(gradingState.graded.results)
         }
+      } else if (e.key === 'ArrowRight' && gradingState && 'graded' in gradingState && !isInputFocused) {
+        e.preventDefault()
+        onComplete(gradingState.graded.results)
       }
     }
 

--- a/yap-frontend/src/components/challenges/TranslationChallenge.tsx
+++ b/yap-frontend/src/components/challenges/TranslationChallenge.tsx
@@ -642,6 +642,11 @@ export function TranslationChallenge({ sentence, onComplete, dueCount, totalCoun
         e.preventDefault()
         handleContinue()
       }
+      else if (e.key === 'ArrowRight' && grade && "graded" in grade && canContinue) {
+        e.preventDefault()
+        handleContinue()
+        return
+      }
 
       const wordStatuses = grade && 'graded' in grade && 'wordStatuses' in grade.graded && grade.graded.wordStatuses
 


### PR DESCRIPTION
## Summary
- allow right arrow to submit or proceed when translation challenges are graded
- allow right arrow to proceed after grading in transcription challenges

## Testing
- `pnpm lint` *(fails: no-empty-object-type, no-unused-vars, no-explicit-any)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b8bd652220832598f76c059959cdd0