### PR TITLE
Improve sentence sorting by multiple rare word frequencies

### DIFF
--- a/generate-data/src/main.rs
+++ b/generate-data/src/main.rs
@@ -1000,19 +1000,24 @@ async fn main() -> anyhow::Result<()> {
         target_language_sentences.sort_by_key(|sentence| {
             // Look up the NLP info for this sentence
             if let Some(info) = sentence_to_info.get(sentence) {
-                // Find the minimum frequency among all lexemes in the sentence
-                let min_freq = info
+                // Find the three least common lexeme frequencies in the sentence
+                let mut frequencies: Vec<_> = info
                     .all_lexemes()
-                    .filter_map(|lexeme| frequency_map.get(&lexeme))
-                    .min()
-                    .copied()
-                    .unwrap_or(0);
+                    .filter_map(|lexeme| frequency_map.get(&lexeme).copied())
+                    .collect();
+                frequencies.sort_unstable();
+
+                let mut frequency_iter = frequencies.into_iter();
+                let least_common = frequency_iter.next().unwrap_or(0);
+                let second_least_common = frequency_iter.next().unwrap_or(0);
+                let third_least_common = frequency_iter.next().unwrap_or(0);
+
                 // Return reversed to sort descending (highest frequency first)
-                std::cmp::Reverse(min_freq)
+                std::cmp::Reverse((least_common, second_least_common, third_least_common))
             } else {
                 // If no NLP info found, put at the end
                 eprintln!("No NLP info found for sentence: {sentence}");
-                std::cmp::Reverse(0)
+                std::cmp::Reverse((0, 0, 0))
             }
         });
 


### PR DESCRIPTION
## Summary
- sort target language sentences using the three least common lexeme frequencies to break ties more effectively

## Testing
- cargo fmt --manifest-path generate-data/Cargo.toml

------
https://chatgpt.com/codex/tasks/task_e_68dac8b38b34832584de9429f55fa3e2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sorts sentences by a tuple of the three least-common lexeme frequencies instead of a single minimum to improve tie-breaking.
> 
> - **Sentence sorting logic (`generate-data/src/main.rs`)**:
>   - Use the three least-common lexeme frequencies `(least, second, third)` as the sort key (with `Reverse`) instead of a single minimum.
>   - Fallbacks: default to `(0, 0, 0)` when NLP info or frequencies are missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58b409904b7699994d18ff14b87c997e42b883d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->