### PR TITLE
Simplify next review message

### DIFF
--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -35,6 +35,15 @@ export function NoCardsReady({
   targetLanguage,
   deck,
 }: NoCardsReadyProps) {
+  let nextTargetLanguageWord: string | null = null;
+  if (nextDueCard && "TargetLanguage" in nextDueCard.card_indicator) {
+    const lexeme = nextDueCard.card_indicator.TargetLanguage.lexeme;
+    nextTargetLanguageWord =
+      "Heteronym" in lexeme
+        ? lexeme.Heteronym.word
+        : lexeme.Multiword;
+  }
+
   const numCanAddTargetLanguage =
     addCardOptions.manual_add.find(
       ([, card_type]) => card_type === "TargetLanguage"
@@ -103,13 +112,29 @@ export function NoCardsReady({
         <div className="flex flex-col gap-2">
           <p className="text-lg">No cards ready for review!</p>
           <p className="text-muted-foreground">
-            Great job! Your next review is{" "}
-            {nextDueCard ? (
-              <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />
+            {nextTargetLanguageWord ? (
+              <>
+                You'll review <span className="font-semibold">
+                  {nextTargetLanguageWord}
+                </span>
+                {nextDueCard ? (
+                  <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />
+                ) : (
+                  "soon"
+                )}
+                .
+              </>
             ) : (
-              "soon"
+              <>
+                Great job! Your next review is{" "}
+                {nextDueCard ? (
+                  <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />
+                ) : (
+                  "soon"
+                )}
+                .
+              </>
             )}
-            .
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- derive the upcoming target-language word directly from the next card summary
- update the empty-review dialog to announce only that target-language term alongside its due time

## Testing
- pnpm lint *(fails: pre-existing lint issues in LanguageSelector, MobileKeyboardTip, auth-dialog, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68da1337d9f88325aae61cd9d6280dd6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shows the next target-language word (when available) with its due time in the empty-review dialog, falling back to the generic message otherwise.
> 
> - **UI**:
>   - **`yap-frontend/src/components/no-cards-ready.tsx`**:
>     - Derives `nextTargetLanguageWord` from `nextDueCard.card_indicator.TargetLanguage.lexeme`.
>     - Updates empty-review text to: "You'll review <word> <time/soon>." when a target-language term is available; otherwise retains the generic next-review timing message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f260855502de05245afab398ee868eb3bb666468. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->