### PR TITLE
Redirect dictionary page when user is unauthorized

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -329,6 +329,16 @@ function DictionaryPage() {
   const weapon = useWeapon()
   const navigate = useNavigate()
 
+  useEffect(() => {
+    if (!userInfo || deck?.type === 'noLanguageSelected') {
+      navigate('/', { replace: true })
+    }
+  }, [userInfo, deck, navigate])
+
+  if (!userInfo || deck?.type === 'noLanguageSelected') {
+    return null
+  }
+
   if (deck?.type !== 'deck') {
     return (
       <TopPageLayout


### PR DESCRIPTION
## Summary
- redirect the dictionary route back to the homepage when no user is logged in or no language is selected
- short-circuit rendering while the redirect occurs to avoid the loading spinner getting stuck

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e9f58ea83c8325a5fb126c6aa1b23f