### PR TITLE
Hide overflow for sync status error

### DIFF
--- a/yap-frontend/src/components/sync-status-dialog.tsx
+++ b/yap-frontend/src/components/sync-status-dialog.tsx
@@ -161,7 +161,7 @@ export function SyncStatusDialog() {
           </div>
 
           {lastSyncError && (
-            <div className="p-3 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-lg">
+            <div className="p-3 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 rounded-lg overflow-hidden">
               <div className="flex items-start justify-between gap-2">
                 <p className="text-sm text-red-600 dark:text-red-400 flex-1 overflow-hidden line-clamp-3">
                   Error: {lastSyncError}


### PR DESCRIPTION
## Summary
- add overflow-hidden to the sync error container so long messages no longer spill outside the dialog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f56b3a6db483259cdf1136c6cc9b43