### PR TITLE
Add toast when pressing number keys in flashcard challenge

### DIFF
--- a/yap-frontend/src/components/Flashcard.tsx
+++ b/yap-frontend/src/components/Flashcard.tsx
@@ -497,6 +497,12 @@ export const Flashcard = function Flashcard({
         return;
       }
 
+      if (["1", "2", "3", "4"].includes(e.key)) {
+        e.preventDefault();
+        toast("Use the arrow keys");
+        return;
+      }
+
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
         e.preventDefault();
       }


### PR DESCRIPTION
## Summary
- show the existing arrow-key reminder toast when users press number keys while reviewing flashcards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69054fb2a8f483258c4bd8329e331338

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents default on number keys 1–4 during review and shows the existing "Use the arrow keys" toast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bbb6c7bac2957d4ddc3bd87925eaba4fabc9fc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->