### PR TITLE
Fix chart dot colors to respect theme variables

### DIFF
--- a/yap-frontend/src/components/FrequencyKnowledgeChart.tsx
+++ b/yap-frontend/src/components/FrequencyKnowledgeChart.tsx
@@ -85,8 +85,16 @@ export function FrequencyKnowledgeChart({
           dataKey="knowledge"
           stroke="var(--color-knowledge)"
           strokeWidth={2}
-          dot={{ r: 4 }}
-          activeDot={{ r: 6 }}
+          dot={{
+            r: 4,
+            stroke: "var(--color-knowledge)",
+            fill: "var(--color-knowledge)",
+          }}
+          activeDot={{
+            r: 6,
+            stroke: "var(--color-knowledge)",
+            fill: "var(--color-knowledge)",
+          }}
         />
       </LineChart>
     </ChartContainer>


### PR DESCRIPTION
## Summary
- ensure the frequency knowledge chart dots use the CSS theme variable for both stroke and fill
- keep active dot styling consistent so light and dark themes render correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69065243adf88325b1a2dd9c5ca94f30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `FrequencyKnowledgeChart` line dots use the theme color for both stroke and fill, including active dots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c0f30021a20e03a43dcbc8e2e71e780bd59a7c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->