### PR TITLE
Add treemap visualization for target language knowledge

### DIFF
--- a/yap-frontend/src/components/stats.tsx
+++ b/yap-frontend/src/components/stats.tsx
@@ -227,9 +227,8 @@ export function Stats({ deck }: StatsProps) {
               Known vs Unknown Written Words
             </h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Each block represents a high-frequency word. Size reflects how
-              often it appears in native material, and color indicates whether
-              you currently have the written card in your deck.
+              Each block represents a word. Size reflects how often it appears
+              in native material, and color indicates whether you have learned it.
             </p>
             <Suspense
               fallback={


### PR DESCRIPTION
## Summary
- expose the most common target-language lexemes and whether they are already tracked through a new deck helper
- add a treemap component that groups known versus unknown written words by frequency and displays supporting metrics
- surface the treemap in the stats graphs section ahead of the existing frequency knowledge chart

## Testing
- pnpm lint *(fails: existing react compiler lint rules in LanguageSelector.tsx and other files)*

------
https://chatgpt.com/codex/tasks/task_e_69067e7de218832594721c0ab07cea6d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose top target-language lexeme knowledge (known status, frequency, stability) from the deck and visualize it as a grouped treemap in the Stats graphs.
> 
> - **Backend (Rust/wasm)**:
>   - Add `Deck::get_target_language_knowledge()` returning top lexemes (limit 5000), skipping zero-frequency, with `word`, `frequency`, `known`, and optional `stability`.
>   - Introduce `TargetLanguageKnowledge` type exported to TS.
> - **Frontend (Stats UI)**:
>   - New `TargetLanguageKnowledgeTreemap` component (Recharts) grouping `Known` vs `Unknown` words; size by `frequency`, opacity by `stability`, with tooltip and summary metrics.
>   - Update `stats.tsx` to lazy-load and display the treemap before the existing frequency knowledge chart.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fbae29ad09a699e3c15303c9f29fc07db73b519. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->