### PR TITLE
Add ElevenLabs playback to flashcard example sentences

### DIFF
--- a/yap-frontend/src/components/Flashcard.tsx
+++ b/yap-frontend/src/components/Flashcard.tsx
@@ -228,16 +228,7 @@ const CardBack = ({
 
         {def.example_sentence_target_language && (
           <div className="space-y-1 text-sm">
-            <div className="flex items-start gap-2 justify-between">
-              <div>
-                <p className="text-muted-foreground italic flex-1">
-                  "{def.example_sentence_target_language}"
-                </p>
-                <p className="text-muted-foreground">
-                  "{def.example_sentence_native_language}"
-                </p>
-              </div>
-
+            <div className="flex items-start gap-2">
               <div onClick={(e) => e.stopPropagation()}>
                 <AudioButton
                   audioRequest={{
@@ -251,6 +242,14 @@ const CardBack = ({
                   className="h-8 w-8"
                   size="icon"
                 />
+              </div>
+              <div>
+                <p className="text-muted-foreground italic flex-1">
+                  "{def.example_sentence_target_language}"
+                </p>
+                <p className="text-muted-foreground">
+                  "{def.example_sentence_native_language}"
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add ElevenLabs audio buttons to flashcard definitions and multiword example sentences so learners can listen to target-language usage

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69112b1fa2f88325b5839837ca23bfdd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ElevenLabs audio buttons for target-language example sentences on definition and multiword flashcards, with minor layout tweaks.
> 
> - **Flashcard (`yap-frontend/src/components/Flashcard.tsx`)**
>   - **Audio playback**:
>     - Add `AudioButton` (provider: `ElevenLabs`) for `Heteronym` definition example sentences; placed before text with click `stopPropagation`.
>     - Add `AudioButton` (provider: `ElevenLabs`) for `Multiword` example sentences; layout adjusted with flex and icon sizing.
>   - **UI adjustments**:
>     - Split rendering of `wordPrefix` into separate `{prefix}` and `{separator}` nodes.
>     - Restructure example sentence blocks using flex containers and spacing for better alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 887c5e8bfa748a7b5ed45af4ba25dfbb5d46ed1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->