### PR TITLE
Fix text wrapping in challenge input boxes

### DIFF
--- a/yap-frontend/src/components/challenges/TranscriptionChallenge.tsx
+++ b/yap-frontend/src/components/challenges/TranscriptionChallenge.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { languageToIso6391 } from "@/lib/utils";
 import {
   InputFieldSizingContent,
-  InputDottedUnderline,
+  TextareaDottedUnderline,
 } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { AudioButton } from "../AudioButton";
@@ -128,7 +128,7 @@ export function TranscriptionChallenge({
   const [focusedInputIndex, setFocusedInputIndex] = useState<number | null>(
     null
   );
-  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const inputRefs = useRef<(HTMLInputElement | HTMLTextAreaElement | null)[]>([]);
   const { bumpBackground } = useBackground();
 
   // Find indices of words that should be blanks
@@ -334,14 +334,36 @@ export function TranscriptionChallenge({
           asked_to_transcribe.parts[asked_to_transcribe.parts.length - 1]
             .whitespace;
 
-        // Use dotted underline for single-part transcriptions, regular input otherwise
-        const InputComponent = isSinglePartTranscription
-          ? InputDottedUnderline
-          : InputFieldSizingContent;
+        // Use textarea for single-part transcriptions (wraps text), regular input otherwise
+        if (isSinglePartTranscription) {
+          return (
+            <span key={index} className="w-full">
+              <TextareaDottedUnderline
+                ref={(el) => {
+                  inputRefs.current[index] = el;
+                }}
+                value={userInputs.get(index) || ""}
+                onChange={(e) => handleInputChange(index, e.target.value)}
+                onFocus={() => setFocusedInputIndex(index)}
+                onBlur={() => {
+                  // Keep track of last focused input but allow blur
+                  // The accent keyboard will refocus when clicked
+                }}
+                disabled={gradingState !== null}
+                lang={languageToIso6391(targetLanguage)}
+                className={`min-w-64 text-center text-2xl font-semibold ${getInputClassName(
+                  index
+                )}`}
+                placeholder="Write what you hear"
+              />
+              <span>{end_whitespace}</span>
+            </span>
+          );
+        }
 
         return (
           <span key={index} className="w-full">
-            <InputComponent
+            <InputFieldSizingContent
               ref={(el) => {
                 inputRefs.current[index] = el;
               }}
@@ -355,9 +377,7 @@ export function TranscriptionChallenge({
               }}
               disabled={gradingState !== null}
               lang={languageToIso6391(targetLanguage)}
-              className={`inline-block ${
-                isSinglePartTranscription ? "min-w-64" : "min-w-32"
-              } mx-1 text-center text-2xl font-semibold ${getInputClassName(
+              className={`inline-block min-w-32 max-w-full mx-1 text-center text-2xl font-semibold ${getInputClassName(
                 index
               )}`}
               placeholder="Write what you hear"

--- a/yap-frontend/src/components/challenges/TranslationChallenge.tsx
+++ b/yap-frontend/src/components/challenges/TranslationChallenge.tsx
@@ -21,7 +21,7 @@ import {
   type Deck,
 } from "../../../../yap-frontend-rs/pkg/yap_frontend_rs";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { TextareaAutoResize } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Card } from "@/components/ui/card";
 import {
@@ -629,7 +629,7 @@ export function TranslationChallenge({
     | { grading: null }
     | null
   >(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const wordRefs = useRef<Map<number, SwipeableWordHandle>>(new Map());
   const { bumpBackground } = useBackground();
 
@@ -977,9 +977,8 @@ export function TranslationChallenge({
 
             {grade === null ? (
               <>
-                <Input
+                <TextareaAutoResize
                   ref={inputRef}
-                  type="text"
                   placeholder="Translation..."
                   value={userTranslation}
                   onChange={(e) => setUserTranslation(e.target.value)}

--- a/yap-frontend/src/components/ui/input.tsx
+++ b/yap-frontend/src/components/ui/input.tsx
@@ -54,4 +54,55 @@ function InputDottedUnderline({ className, type, ...props }: React.ComponentProp
   );
 }
 
-export { Input, InputFieldSizingContent, InputDottedUnderline };
+// Auto-resizing textarea that wraps text and grows with content
+function TextareaAutoResize({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      rows={1}
+      className={cn(
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex w-full min-w-0 rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "field-sizing-content resize-none",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+// Auto-resizing textarea with dotted underline style (for transcription)
+function TextareaDottedUnderline({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      rows={1}
+      className={cn(
+        "placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground",
+        "flex w-full min-w-0 bg-transparent px-1 py-0.5 text-base outline-none transition-colors",
+        "border-0 border-b-2 border-dotted border-muted-foreground/50 rounded-none",
+        "focus:border-primary focus:border-solid",
+        "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "md:text-sm",
+        "field-sizing-content resize-none",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Input,
+  InputFieldSizingContent,
+  InputDottedUnderline,
+  TextareaAutoResize,
+  TextareaDottedUnderline,
+};


### PR DESCRIPTION
- Add TextareaAutoResize and TextareaDottedUnderline components that use field-sizing: content with text wrapping support
- Update TranslationChallenge to use TextareaAutoResize for better mobile experience with long translations
- Update TranscriptionChallenge to use TextareaDottedUnderline for single-part (full sentence) transcription, which now wraps text
- Add max-w-full constraint to multi-part transcription inputs to prevent overflow on mobile