### PR TITLE
Filter out sentences containing colons

### DIFF
--- a/generate-data/src/target_sentences.rs
+++ b/generate-data/src/target_sentences.rs
@@ -601,5 +601,10 @@ fn is_proper_sentence(text: &str, language: Language) -> bool {
         return false;
     }
 
+    // Reject sentences with colons (often speaker attribution in subtitles)
+    if text.contains(':') {
+        return false;
+    }
+
     true
 }


### PR DESCRIPTION
Subtitles often use colons for speaker attribution (e.g., "Speaker: dialogue"), which aren't suitable for language learning flashcards.