### PR TITLE
PWA installation button via HTML <install> element (origin trial)

### DIFF
--- a/yap-frontend/index.html
+++ b/yap-frontend/index.html
@@ -2,6 +2,9 @@
   <head>
     <meta charset="UTF-8" />
 
+    <!-- HTML <install> element origin trial (yap.town, expires 2026-10-05) -->
+    <meta http-equiv="origin-trial" content="Ai6haKgC43rcRmK3I6dLFmVwROaPTccLb9BOi/5uIvSMqod0YnHv4YneMb0A3QpY7pZ7gqWcSpXsy5pzX2NCoAIAAABQeyJvcmlnaW4iOiJodHRwczovL3lhcC50b3duOjQ0MyIsImZlYXR1cmUiOiJJbnN0YWxsRWxlbWVudCIsImV4cGlyeSI6MTc5MTI0NDgwMH0=" />
+
     <!-- onesignal setup -->
     <script src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
     <script>

--- a/yap-frontend/src/components/InstallPwaButton.tsx
+++ b/yap-frontend/src/components/InstallPwaButton.tsx
@@ -3,6 +3,23 @@ import { Button } from "@/components/ui/button";
 import { Home } from "lucide-react";
 import { AddToHomeScreenModal } from "@/components/add-to-home-screen-modal";
 
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      install: React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          installurl?: string;
+          manifestid?: string;
+        },
+        HTMLElement
+      >;
+    }
+  }
+}
+
+const hasInstallElement =
+  typeof window !== "undefined" && "HTMLInstallElement" in window;
+
 interface InstallPwaButtonProps {
   variant?:
     | "default"
@@ -21,6 +38,10 @@ export function InstallPwaButton({
   className,
 }: InstallPwaButtonProps) {
   const [showModal, setShowModal] = useState(false);
+
+  if (hasInstallElement) {
+    return <install className={className} />;
+  }
 
   return (
     <>


### PR DESCRIPTION
Uses the native HTML `<install>` element when the browser supports it (`HTMLInstallElement`), falling back to the existing add-to-home-screen modal otherwise. Registers the yap.town origin-trial token (expires 2026-10-05).

Split out of the `human-audio` WIP branch as an independent change.

Reviewer note: in supported browsers the wrapper renders a bare browser-controlled `<install>` and drops the `variant`/`size`/`className` styling the shadcn button path uses — fine if intended, but worth confirming the layout at call sites that pass those props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)