### PR TITLE
Suppress noisy service worker update errors from Sentry

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -119,10 +119,9 @@ function AppMain() {
     onRegistered(r) {
       if (r) {
         setInterval(() => {
-          r.update().catch((e) => {
-            if (navigator.onLine) {
-              Sentry.captureException(e, { tags: { "sw.online": true } });
-            }
+          r.update().catch(() => {
+            // SW update failures (InvalidStateError, network errors) are transient
+            // lifecycle races, not actionable — suppress from error tracking.
           });
         }, updateIntervalMS);
       }

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -17,9 +17,14 @@ Sentry.init({
   ],
 
   beforeSend(event) {
-    // Filter out browser extension errors (not our code)
     const message = event.exception?.values?.[0]?.value ?? "";
+    // Filter out browser extension errors (not our code)
     if (message.includes("runtime.sendMessage()")) {
+      return null;
+    }
+    // Filter out transient service worker update failures — these are
+    // lifecycle race conditions, not actionable bugs.
+    if (message.includes("Failed to update a ServiceWorker")) {
       return null;
     }
     return event;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Reviewed recent Sentry issues and found 4 recurring errors that are all caused by the same root issue: service worker `update()` calls occasionally fail with `InvalidStateError` when the SW registration is in a transitional lifecycle state. These are benign race conditions — the SW simply wasn't ready yet at the moment the interval fired — but they were being forwarded to Sentry as real errors.

- **JAVASCRIPT-REACT-1T** (`InvalidStateError: newestWorker is null`, 13 events) — caught by our handler and explicitly sent to Sentry
- **JAVASCRIPT-REACT-2F** (`InvalidStateError: Failed to update a ServiceWorker ... The object is in an invalid state.`, 7 events) — same path
- **JAVASCRIPT-REACT-2D** (`TypeError: Cannot update a null/nonexistent service worker registration`, 2 events) — same path  
- **JAVASCRIPT-REACT-2G** (`TypeError: Failed to update a ServiceWorker ... An unknown error occurred when fetching the script.`, 2 events) — surfaced as unhandled

### Changes

- **`App.tsx`**: Remove `Sentry.captureException` from `r.update().catch()`. The catch is kept so it doesn't become an unhandled rejection, but the errors are swallowed since they're not actionable.
- **`instrument.ts`**: Add a `beforeSend` filter for `"Failed to update a ServiceWorker"` to catch any instances that surface as unhandled exceptions (covers 2G and any future regressions).

## Test plan

- [ ] Verify app loads and service worker registers normally in production
- [ ] Confirm the 4 Sentry issues stop receiving new events after deploy

https://claude.ai/code/session_01T667PPV2zEevEgk8XnHJaF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T667PPV2zEevEgk8XnHJaF)_