### PR TITLE
Stop capturing transient SW update failures to Sentry

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -120,9 +120,7 @@ function AppMain() {
       if (r) {
         setInterval(() => {
           r.update().catch((e) => {
-            if (navigator.onLine) {
-              Sentry.captureException(e, { tags: { "sw.online": true } });
-            }
+            console.warn("Service worker update failed:", e);
           });
         }, updateIntervalMS);
       }


### PR DESCRIPTION
## Summary

- Reviewed recent Sentry production issues (JAVASCRIPT-REACT-2G, JAVASCRIPT-REACT-2M)
- The service worker update error was being explicitly captured to Sentry via `Sentry.captureException`, but it's a transient network fetch failure with no actionable signal — the SW simply retries on the next interval
- Replaced the Sentry capture with a `console.warn` to silence the noise
- The other open issue (stack overflow in `src/preload/document.js`) is caused by a browser extension injecting into the page, not our code — nothing to fix

## Test plan

- [ ] Confirm no new SW-related errors appear in Sentry after deploy
- [ ] Verify the app still registers and updates its service worker normally

https://claude.ai/code/session_01JAXu8uj1KqAfVoufykfcyA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAXu8uj1KqAfVoufykfcyA)_