### PR TITLE
fix: stop reporting unactionable ServiceWorker update errors to Sentry

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -56,7 +56,6 @@ import { LandingPage } from "@/pages/landing";
 import { NotFoundPage } from "@/pages/not-found";
 import { GoalsPage } from "@/pages/goals";
 import { playSoundEffect } from "@/lib/sound-effects";
-import { registerSW } from "virtual:pwa-register";
 import { NoCardsReady } from "@/components/no-cards-ready";
 import { AccomplishmentScreen } from "@/components/AccomplishmentScreen";
 import { useGoal, goalToGoalSelection } from "@/hooks/useGoal";
@@ -110,16 +109,19 @@ export type AppContextType = {
 
 function AppMain() {
   const updateIntervalMS = 60 * 5 * 1000; // every 5 minutes
-  useEffect(() => {
-    registerSW({ immediate: true });
-  }, []);
 
   useRegisterSW({
     onRegistered(r) {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            if (navigator.onLine && e?.name !== "InvalidStateError") {
+            // TypeError covers browser-internal SW failures (network errors, script fetch
+            // failures, uninstalled registrations) — none are actionable from app code.
+            if (
+              navigator.onLine &&
+              e?.name !== "InvalidStateError" &&
+              e?.name !== "TypeError"
+            ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }
           });


### PR DESCRIPTION
## Summary

Two recurring Sentry issues (JAVASCRIPT-REACT-2Q and JAVASCRIPT-REACT-2G) were both `TypeError`s thrown by `ServiceWorkerRegistration.update()` — browser-internal errors with no stack trace that app code cannot act on:

- **JAVASCRIPT-REACT-2Q**: "registration has been uninstalled since the update was scheduled" — SW was unregistered between scheduling an update and executing it
- **JAVASCRIPT-REACT-2G**: "unknown error occurred when fetching the script" — network error during SW script fetch

Two fixes in `AppMain()`:

1. **Remove redundant `registerSW({ immediate: true })` call** — this was racing with the `useRegisterSW` hook, both independently registering the SW. The race was likely the root cause of the "uninstalled since the update was scheduled" error: one registration would invalidate the other mid-update. The `useRegisterSW` hook already handles registration, so the imperative call was unnecessary.

2. **Filter `TypeError` from SW update error reporting** — `ServiceWorkerRegistration.update()` throws `TypeError` for all browser-internal failures (network errors, script fetch failures, uninstalled registrations). These are not actionable from app code, have no stack trace, and are not worth tracking in Sentry. `InvalidStateError` was already filtered; this extends that pattern to `TypeError`.

## Test plan

- [ ] Verify app loads and functions normally
- [ ] Confirm service worker is still registered (check DevTools → Application → Service Workers)
- [ ] Confirm periodic update checks still fire every 5 minutes
- [ ] No new Sentry errors from SW update handling

https://claude.ai/code/session_01JGLz2mvwB1bGeCH6K3NaTH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGLz2mvwB1bGeCH6K3NaTH)_