### PR TITLE
rename: get_language_pack -> load_language_pack

### DIFF
--- a/yap-frontend-rs/src/language_pack.rs
+++ b/yap-frontend-rs/src/language_pack.rs
@@ -153,12 +153,12 @@ fn is_retryable_persistent_error(error: &persistent::Error) -> bool {
         || error_text.contains("out of memory")
 }
 
-pub(crate) async fn get_language_pack(
+pub(crate) async fn load_language_pack(
     data_directory_handle: &DirectoryHandle,
     course: Course,
     set_loading_state: &impl Fn(&str, f32),
 ) -> Result<LanguagePack, LanguageDataError> {
-    let _perf_timer = utils::PerfTimer::new("get_language_pack");
+    let _perf_timer = utils::PerfTimer::new("load_language_pack");
     let course_directory = course_directory_slug(course);
     let mut language_directory = data_directory_handle
         .get_directory_handle_with_options(

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -564,7 +564,7 @@ impl Weapon {
         &self,
         course: Course,
     ) -> Result<(), language_pack::LanguageDataError> {
-        self.get_language_pack(course, None).await?;
+        self.load_language_pack(course, None).await?;
         Ok(())
     }
 }
@@ -572,7 +572,7 @@ impl Weapon {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 impl Weapon {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub async fn get_language_pack(
+    pub async fn load_language_pack(
         &self,
         course: Course,
         on_progress: Option<js_sys::Function>,
@@ -592,7 +592,7 @@ impl Weapon {
             return Ok(());
         }
 
-        let language_pack = language_pack::get_language_pack(
+        let language_pack = language_pack::load_language_pack(
             &self.directories.data_directory_handle,
             course,
             &|message: &str, progress: f32| {

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -1540,7 +1540,7 @@ export function useDeck():
       level: "info",
     });
     try {
-      await weapon.get_language_pack(
+      await weapon.load_language_pack(
         course,
         (message: string, progress: number) => {
           Sentry.addBreadcrumb({


### PR DESCRIPTION
## Why the old name was misleading

`get_language_pack` reads as a pure accessor — callers expect to receive a value and nothing else. But the method signature is `async fn get_language_pack(...) -> Result<(), LanguageDataError>`: it returns *nothing* (`()`), acquires an exclusive async lock, reads data from OPFS disk, and inserts the result into `self.language_pack`. Even the TypeScript call site already described it correctly with a Sentry breadcrumb saying `"Loading language pack"`.

## What the new name conveys

`load_language_pack` signals an effectful, async operation that fetches data and installs it into the struct's internal state — matching both the return type and the actual behavior. The rename applies to the `wasm_bindgen`-exposed method on `Weapon`, the private `language_pack::load_language_pack` helper it delegates to, and the single TypeScript call site in `App.tsx`.

## Before / after

```rust
// before
await weapon.get_language_pack(course, on_progress);   // TS caller

pub async fn get_language_pack(&self, course: Course, ...) -> Result<(), LanguageDataError>

// after
await weapon.load_language_pack(course, on_progress);  // TS caller

pub async fn load_language_pack(&self, course: Course, ...) -> Result<(), LanguageDataError>
```

## Verification

```
cargo build -p yap-frontend-rs   # ✓ clean
cargo clippy -p yap-frontend-rs  # ✓ no warnings
grep -r get_language_pack        # ✓ no remaining references
```

https://claude.ai/code/session_011ad7JbWVAC6u1Zv5tMB6BH

---
_Generated by [Claude Code](https://claude.ai/code/session_011ad7JbWVAC6u1Zv5tMB6BH)_