### PR TITLE
Fix Sentry errors: JWT unhandled rejection and WASM externref crash on old browsers

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -183,6 +183,8 @@ function AppCheckLoggedIn({ weaponToken }: { weaponToken: WeaponToken }) {
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
+    }).catch(() => {
+      setSession(null);
     });
 
     const { data: authListener } = supabase.auth.onAuthStateChange(

--- a/yap-frontend/src/weapon.tsx
+++ b/yap-frontend/src/weapon.tsx
@@ -303,12 +303,38 @@ export function useSyncActions(): {
   return ctx;
 }
 
+// Minimal WASM module using externref (reference types). Returns false on
+// browsers that predate Chrome 86 / Firefox 79 where externref was behind a
+// flag — those browsers can't compile our WASM module at all.
+function supportsWasmExternref(): boolean {
+  try {
+    return WebAssembly.validate(
+      new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x6f, // type section: () -> externref
+        0x03, 0x02, 0x01, 0x00, // function section
+        0x0a, 0x06, 0x01, 0x04, 0x00, 0xd0, 0x6f, 0x0b, // code section
+      ]),
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function checkBrowserSupport(
   setBrowserSupported: (browserSupported: boolean) => void,
 ) {
   try {
     // Check if OPFS test has already passed
     const opfsTestPassed = localStorage.getItem("opfs-test-passed");
+
+    // Reject browsers that don't support WebAssembly reference types
+    // (externref). Our WASM module uses externref, so it can't compile on
+    // Chrome < 86 / Firefox < 79 even if OPFS were somehow present.
+    if (!supportsWasmExternref()) {
+      setBrowserSupported(false);
+      return;
+    }
 
     // Quick JS-level check before calling into WASM (avoids noisy TypeErrors
     // on browsers that lack OPFS entirely or don't support createWritable)


### PR DESCRIPTION
## Summary

Fixes two unambiguous production errors found in Sentry:

- **JAVASCRIPT-REACT-14** — `UnhandledRejection: InvalidJWTToken: Invalid value for JWT claim "exp"` (2 users, ongoing since March 2026, culprit: `/learn`). The `supabase.auth.getSession().then(...)` call in `App.tsx` had no `.catch()`. In edge cases where the Supabase SDK rejects the promise internally during token refresh (e.g. a corrupted or invalid JWT stored in localStorage), this bubbles up as an unhandled rejection. Added `.catch(() => setSession(null))`.

- **JAVASCRIPT-REACT-26** — `CompileError: WebAssembly.instantiateStreaming(): invalid value type 'externref'` (Chrome 75 / Android 6.0). Our WASM module uses WebAssembly reference types (`externref`), which were only unflagged in Chrome 86+. The existing OPFS API check theoretically gates these browsers out, but the WASM `CompileError` was still surfacing (likely due to eager module evaluation by the bundler). Added an explicit `supportsWasmExternref()` check using `WebAssembly.validate()` with a tiny test binary — this runs synchronously before any WASM call and marks the browser as unsupported immediately.

## Skipped issues

The remaining Sentry issues are not fixable in code:
- Multiple service worker update errors (`InvalidStateError`, `Failed to fetch sw.js`, etc.) — these are browser/network/lifecycle errors unrelated to our app logic
- `RangeError: Maximum call stack size exceeded` in `src/preload/document.js` — this is from a browser extension injecting into the page, not our code
- `TypeError: undefined is not an object (evaluating 'OneSignal.ye.Qe')` — third-party minified code in OneSignal SDK
- `TypeError: error loading dynamically imported module` — transient network failure fetching a chunk

## Test plan

- [ ] Verify TypeScript compiles cleanly (`pnpm tsc -b`)
- [ ] Verify no lint regressions (`pnpm lint`)
- [ ] On a fresh session with a corrupted JWT in localStorage, confirm no unhandled rejection fires
- [ ] Confirm `supportsWasmExternref()` returns `false` in a browser console with reference types disabled, and the app shows the "Browser Not Supported" screen

https://claude.ai/code/session_01G5WAsKG6uahvxyQq5WQLvC

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5WAsKG6uahvxyQq5WQLvC)_