### PR TITLE
Filter transient network errors from Sentry

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -119,7 +119,13 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            if (navigator.onLine && e?.name !== "InvalidStateError") {
+            // Skip network-level fetch failures (TypeError) and InvalidStateError
+            // — these are transient errors that aren't actionable bugs.
+            if (
+              navigator.onLine &&
+              e?.name !== "InvalidStateError" &&
+              e?.name !== "TypeError"
+            ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }
           });

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -17,11 +17,30 @@ Sentry.init({
   ],
 
   beforeSend(event) {
-    // Filter out browser extension errors (not our code)
     const message = event.exception?.values?.[0]?.value ?? "";
+
+    // Filter out browser extension errors (not our code)
     if (message.includes("runtime.sendMessage()")) {
       return null;
     }
+
+    // Filter WASM fetch failures on iOS/WKWebView. These are transient network
+    // errors during .wasm module initialization — identifiable by "Load failed"
+    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
+    if (message === "Load failed") {
+      const frames =
+        event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+      if (
+        frames.some(
+          (f) =>
+            f.filename?.includes("wasm-helper") ||
+            f.filename?.includes("_bg.wasm"),
+        )
+      ) {
+        return null;
+      }
+    }
+
     return event;
   },
 


### PR DESCRIPTION
## Summary

Two recurring Sentry issues were transient network errors with no actionable fix:

- **JAVASCRIPT-REACT-2J** (`TypeError: Load failed`): iOS/WKWebView fails to fetch the `.wasm` file during module initialization. Because vite-plugin-wasm uses top-level await in the generated module code, the rejection escapes all try-catch blocks and surfaces in global error handlers as `handled: no`. Fixed by filtering in `beforeSend` — matches on `"Load failed"` + WASM-related frames in the stacktrace, so it won't swallow unrelated load failures.

- **JAVASCRIPT-REACT-2G** (`TypeError: Failed to update a ServiceWorker...`): The SW update catch block already existed but still reported `TypeError`s to Sentry when `navigator.onLine`. All `TypeError`s from `r.update()` are browser-level network failures fetching `sw.js` — not bugs. Added `TypeError` to the skip list alongside the existing `InvalidStateError` guard.

## Test plan

- [ ] Verify the app still works normally in dev
- [ ] Confirm a real WASM load failure (e.g. offline then reload on iOS) shows the existing error UI without generating a new Sentry event
- [ ] Confirm SW update failures no longer appear in Sentry noise

https://claude.ai/code/session_01RKRRzVyoFYUc6LQXo6ryrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKRRzVyoFYUc6LQXo6ryrc)_