### PR TITLE
rename: set_sentence_list -> change_sentence_list

### DIFF
--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -2700,7 +2700,7 @@ impl Deck {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn set_sentence_list(&self, sentence_list: Option<SentenceListSelection>) -> DeckEvent {
+    pub fn change_sentence_list(&self, sentence_list: Option<SentenceListSelection>) -> DeckEvent {
         DeckEvent::Language(LanguageEvent {
             target_language: self.context.course.target_language,
             native_language: self.context.course.native_language,
@@ -5612,14 +5612,14 @@ mod tests {
     }
 
     #[test]
-    fn test_set_sentence_list_does_not_increment_review_stats() {
+    fn test_change_sentence_list_does_not_increment_review_stats() {
         use crate::{Deck, DeckState, SentenceListSelection};
         use weapon::AppState;
         use weapon::data_model::Timestamped;
 
         let deck = Deck::default();
         let context = deck.context.clone();
-        let event = deck.set_sentence_list(Some(SentenceListSelection::Movie {
+        let event = deck.change_sentence_list(Some(SentenceListSelection::Movie {
             id: "tt0111161".to_string(),
         }));
         let timestamped = Timestamped {

--- a/yap-frontend/src/pages/sentence-lists.tsx
+++ b/yap-frontend/src/pages/sentence-lists.tsx
@@ -51,7 +51,7 @@ export function SentenceListsPage() {
       { type: "deck", deck: P.not(P.nullish) },
       ({ deck, targetLanguage }) => {
         const setSentenceListAndNavigate = (sl: SentenceList) => {
-          const event = deck.set_sentence_list(sentenceListToSelection(sl));
+          const event = deck.change_sentence_list(sentenceListToSelection(sl));
           weapon.add_deck_event(event);
           navigate("/learn");
         };


### PR DESCRIPTION
## Why `set_sentence_list` was misleading

`set_sentence_list` takes `&self` (not `&mut self`) and returns a `DeckEvent` — it's an event builder, not a setter. Nothing changes until the returned event is applied via `weapon.add_deck_event(event)`. The `set_` prefix in Rust strongly signals in-place mutation, so the name created a wrong mental model.

`change_sentence_list` matches the action-verb convention of `review_card` and `complete_placement_test`, which also take `&self` and return a `DeckEvent`.

> Note: this PR was originally `set_goal -> change_goal`; main renamed the goal concept to *sentence list* in the meantime, so the branch was rebuilt on current main applying the equivalent rename (`yap-frontend-rs/src/lib.rs` definition + test, `yap-frontend/src/pages/sentence-lists.tsx` call site).