### PR TITLE
Fix WASM panics from unhandled failures in core flows

### DIFF
--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -586,7 +586,12 @@ impl Weapon {
             weblocks::AcquireOptions::exclusive(),
         )
         .await
-        .unwrap();
+        .map_err(|e| {
+            language_pack::LanguageDataError::InvalidData(
+                e.as_string()
+                    .unwrap_or_else(|| "Failed to acquire language pack lock".to_string()),
+            )
+        })?;
 
         if self.language_pack.borrow().get(&course).is_some() {
             return Ok(());
@@ -2428,12 +2433,20 @@ impl Deck {
             loop {
                 // Yield to the main thread to avoid blocking old devices
                 let promise = js_sys::Promise::new(&mut |resolve, _| {
-                    web_sys::window()
-                        .unwrap()
-                        .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 200)
-                        .unwrap();
+                    if let Some(window) = web_sys::window() {
+                        if window
+                            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 200)
+                            .is_err()
+                        {
+                            // setTimeout failed; resolve immediately rather than hanging
+                            let _ = resolve.call0(&wasm_bindgen::JsValue::UNDEFINED);
+                        }
+                    } else {
+                        // No window (e.g. Worker context); resolve immediately
+                        let _ = resolve.call0(&wasm_bindgen::JsValue::UNDEFINED);
+                    }
                 });
-                wasm_bindgen_futures::JsFuture::from(promise).await.unwrap();
+                let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
 
                 // Early return (not just break) so we skip the audio cleanup below,
                 // preserving any previously cached files that may still be useful.
@@ -2895,7 +2908,7 @@ impl Deck {
         }
 
         // Sort by percent known descending
-        stats.sort_by(|a, b| b.percent_known.partial_cmp(&a.percent_known).unwrap());
+        stats.sort_by(|a, b| b.percent_known.total_cmp(&a.percent_known));
 
         stats
     }
@@ -3666,8 +3679,7 @@ impl Deck {
 
             let native_languages = language_pack
                 .translations
-                .get(&target_language_sentence)
-                .unwrap()
+                .get(&target_language_sentence)?
                 .clone();
 
             return Some(ComprehensibleSentence {


### PR DESCRIPTION
## Summary

Sentry MCP wasn't available, so I audited the codebase for panic paths that would crash the WASM module in production. Found four in `yap-frontend-rs/src/lib.rs`:

- **`weblocks::acquire().unwrap()` in `load_language_pack`** — If `navigator.locks` is unavailable (old Safari <15.4, some private/restricted browser modes), this panics and kills the WASM module, making language pack loading permanently broken for that session. Now propagates as `LanguageDataError::InvalidData` so the frontend can show a retry UI.

- **`window().unwrap()` and `set_timeout().unwrap()` in `cache_challenge_audio`** — These panic if called without a `window` global (Worker context) or if `setTimeout` fails. Changed to resolve the yielding promise immediately in those cases so the audio cache loop continues gracefully.

- **`partial_cmp().unwrap()` in `get_movie_stats`** — Sorting movie stats by `percent_known` (`f64`) via `partial_cmp` panics on NaN. Replaced with `total_cmp` which is NaN-safe.

- **`.get().unwrap()` on translations lookup in `get_comprehensible_sentence_containing`** — The surrounding loop already filters for sentences with translations, so this `.unwrap()` is logically safe, but swapping it to `?` eliminates the panic path and makes the code's intent explicit.

## Test plan

- [ ] `cargo check --package yap-frontend-rs` passes ✅
- [ ] `cargo clippy --package yap-frontend-rs` clean ✅
- [ ] Language pack loading still works end-to-end in a normal browser
- [ ] Movie stats page still sorts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163B5F2yEtmEBp6GBU9YHnF

---
_Generated by [Claude Code](https://claude.ai/code/session_0163B5F2yEtmEBp6GBU9YHnF)_