### PR TITLE
rename: get_uuid -> generate_uuid

### DIFF
--- a/libraries/eyedee/src/lib.rs
+++ b/libraries/eyedee/src/lib.rs
@@ -11,7 +11,7 @@ extern "C" {
     fn randomUUID() -> String;
 }
 
-pub fn get_uuid() -> String {
+pub fn generate_uuid() -> String {
     #[cfg(target_arch = "wasm32")]
     {
         randomUUID()
@@ -28,9 +28,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_uuid() {
-        let uuid1 = get_uuid();
-        let uuid2 = get_uuid();
+    fn test_generate_uuid() {
+        let uuid1 = generate_uuid();
+        let uuid2 = generate_uuid();
 
         assert_ne!(uuid1, uuid2);
         assert_eq!(uuid1.len(), 36);

--- a/yap-frontend-rs/src/utils.rs
+++ b/yap-frontend-rs/src/utils.rs
@@ -124,13 +124,13 @@ pub(crate) async fn get_or_create_device_id(
             let bytes = file_handle.read().await?;
             let device_id = String::from_utf8(bytes).unwrap_or_else(|_| {
                 log::error!("Device ID file contained invalid UTF-8 data");
-                eyedee::get_uuid()
+                eyedee::generate_uuid()
             });
             Ok(device_id)
         }
         Err(_) => {
             // Generate new device ID
-            let device_id = eyedee::get_uuid();
+            let device_id = eyedee::generate_uuid();
 
             // Save it to OPFS
             let mut file_handle = weapon_dir


### PR DESCRIPTION
## Why the old name was misleading

`get_uuid` follows the Rust `get_` convention, which universally signals a cheap read of already-existing state (think `Vec::get`, `HashMap::get`, `Option::get`). A reader seeing `eyedee::get_uuid()` would naturally assume it retrieves a stored or cached identifier. In reality it **creates** a brand-new UUID on every single call — `crypto.randomUUID()` on WASM, `Uuid::new_v4()` on native — and the test explicitly asserts that successive calls return different values.

## What the new name conveys

`generate_uuid` makes the side-effect visible at the call site: something is being produced, not fetched. This matches how similar functions are named throughout the Rust ecosystem (`rand::random`, `Uuid::new_v4`, etc.).

## Before / After

```rust
// Before — implies retrieval
let device_id = eyedee::get_uuid();

// After — implies creation
let device_id = eyedee::generate_uuid();
```

## Build & test

```
cargo build          # exit 0 — full workspace compiled clean
cargo test -p eyedee # exit 0 — test_generate_uuid passes
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRP2cTkmBTAfKLZRPNc6iK)_