### PR TITLE
Record timezone information alongside event timestamps

### DIFF
--- a/libraries/course-spot-check/src/clear_translation_cache.rs
+++ b/libraries/course-spot-check/src/clear_translation_cache.rs
@@ -74,6 +74,7 @@ fn create_deck_for_course(course: Course) -> Result<Deck> {
         let ts = Timestamped {
             timestamp: Utc::now(),
             within_device_events_index: 0,
+            timezone: context.timezone,
             event,
         };
         let state = DeckState::from(deck);

--- a/libraries/course-spot-check/src/clear_translation_cache.rs
+++ b/libraries/course-spot-check/src/clear_translation_cache.rs
@@ -74,7 +74,7 @@ fn create_deck_for_course(course: Course) -> Result<Deck> {
         let ts = Timestamped {
             timestamp: Utc::now(),
             within_device_events_index: 0,
-            timezone: context.timezone,
+            timezone: Some(context.timezone),
             event,
         };
         let state = DeckState::from(deck);

--- a/libraries/course-spot-check/src/main.rs
+++ b/libraries/course-spot-check/src/main.rs
@@ -441,6 +441,7 @@ fn create_deck_for_course(course: Course) -> Result<Deck> {
         let ts = Timestamped {
             timestamp: Utc::now(),
             within_device_events_index: 0,
+            timezone: context.timezone,
             event,
         };
         let state = DeckState::from(deck);

--- a/libraries/course-spot-check/src/main.rs
+++ b/libraries/course-spot-check/src/main.rs
@@ -441,7 +441,7 @@ fn create_deck_for_course(course: Course) -> Result<Deck> {
         let ts = Timestamped {
             timestamp: Utc::now(),
             within_device_events_index: 0,
-            timezone: context.timezone,
+            timezone: Some(context.timezone),
             event,
         };
         let state = DeckState::from(deck);

--- a/libraries/weapon/src/data_model/3-timestamped.rs
+++ b/libraries/weapon/src/data_model/3-timestamped.rs
@@ -8,32 +8,32 @@
 //! Alongside the UTC `timestamp`, we record the user's `timezone` (offset from UTC) at the moment
 //! the event was created. This lets us reason about local time-of-day, streaks, and behavior
 //! patterns without losing information to UTC normalization. Events serialized before this field
-//! existed deserialize with a UTC (`+00:00`) offset via [`default_timezone`].
+//! existed deserialize to `None`; consumers fall back to the deck's current timezone for those,
+//! preserving the pre-timezone bucketing behavior for already-persisted history.
 
-/// Default timezone (UTC) for events serialized before the `timezone` field existed.
-fn default_timezone() -> chrono::FixedOffset {
-    chrono::FixedOffset::east_opt(0).expect("UTC offset is always valid")
-}
-
-/// (De)serialize a `chrono::FixedOffset` as its offset-from-UTC in seconds (`i32`).
+/// (De)serialize an `Option<chrono::FixedOffset>` as its offset-from-UTC in seconds (`i32`).
 ///
 /// `FixedOffset` has no `Serialize`/`Deserialize`/`Ord` impls we can rely on here, so we store
-/// the raw `local_minus_utc()` seconds. This is stable on disk and trivially orderable.
+/// the raw `local_minus_utc()` seconds. This is stable on disk and trivially orderable. `None`
+/// (an event recorded before timezones existed) round-trips as a missing/null field.
 mod timezone_serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     pub fn serialize<S: Serializer>(
-        tz: &chrono::FixedOffset,
+        tz: &Option<chrono::FixedOffset>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        tz.local_minus_utc().serialize(serializer)
+        tz.map(|tz| tz.local_minus_utc()).serialize(serializer)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
-    ) -> Result<chrono::FixedOffset, D::Error> {
-        let seconds = i32::deserialize(deserializer)?;
+    ) -> Result<Option<chrono::FixedOffset>, D::Error> {
+        let Some(seconds) = Option::<i32>::deserialize(deserializer)? else {
+            return Ok(None);
+        };
         chrono::FixedOffset::east_opt(seconds)
+            .map(Some)
             .ok_or_else(|| serde::de::Error::custom("invalid timezone offset"))
     }
 }
@@ -44,10 +44,12 @@ mod timezone_serde {
 pub struct Timestamped<E> {
     pub timestamp: chrono::DateTime<chrono::Utc>,
     pub within_device_events_index: usize,
-    /// The user's timezone (offset from UTC, in seconds) when the event was created.
-    #[serde(default = "default_timezone", with = "timezone_serde")]
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "number"))]
-    pub timezone: chrono::FixedOffset,
+    /// The user's timezone (offset from UTC, in seconds) when the event was created. `None` for
+    /// events recorded before this field existed — consumers fall back to the deck's current
+    /// timezone for those.
+    #[serde(default, with = "timezone_serde")]
+    #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "number"))]
+    pub timezone: Option<chrono::FixedOffset>,
     pub event: E,
 }
 

--- a/libraries/weapon/src/data_model/3-timestamped.rs
+++ b/libraries/weapon/src/data_model/3-timestamped.rs
@@ -4,14 +4,75 @@
 //! The nth event created by a device has a `within_device_events_index` of n.
 //!
 //! Events must also be able to be put in order across devices. This is enabled via the `timestamp` field.
+//!
+//! Alongside the UTC `timestamp`, we record the user's `timezone` (offset from UTC) at the moment
+//! the event was created. This lets us reason about local time-of-day, streaks, and behavior
+//! patterns without losing information to UTC normalization. Events serialized before this field
+//! existed deserialize with a UTC (`+00:00`) offset via [`default_timezone`].
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Ord, PartialOrd)]
+/// Default timezone (UTC) for events serialized before the `timezone` field existed.
+fn default_timezone() -> chrono::FixedOffset {
+    chrono::FixedOffset::east_opt(0).expect("UTC offset is always valid")
+}
+
+/// (De)serialize a `chrono::FixedOffset` as its offset-from-UTC in seconds (`i32`).
+///
+/// `FixedOffset` has no `Serialize`/`Deserialize`/`Ord` impls we can rely on here, so we store
+/// the raw `local_minus_utc()` seconds. This is stable on disk and trivially orderable.
+mod timezone_serde {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(
+        tz: &chrono::FixedOffset,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        tz.local_minus_utc().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<chrono::FixedOffset, D::Error> {
+        let seconds = i32::deserialize(deserializer)?;
+        chrono::FixedOffset::east_opt(seconds)
+            .ok_or_else(|| serde::de::Error::custom("invalid timezone offset"))
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
 pub struct Timestamped<E> {
     pub timestamp: chrono::DateTime<chrono::Utc>,
     pub within_device_events_index: usize,
+    /// The user's timezone (offset from UTC, in seconds) when the event was created.
+    #[serde(default = "default_timezone", with = "timezone_serde")]
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "number"))]
+    pub timezone: chrono::FixedOffset,
     pub event: E,
+}
+
+/// Ordering ignores `timezone`: events are ordered by `(timestamp, within_device_events_index,
+/// event)`, matching the pre-timezone behavior. `FixedOffset` carries no ordering meaning here
+/// and including it would only break ties between otherwise-identical events.
+impl<E: Ord> Ord for Timestamped<E> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (
+            &self.timestamp,
+            &self.within_device_events_index,
+            &self.event,
+        )
+            .cmp(&(
+                &other.timestamp,
+                &other.within_device_events_index,
+                &other.event,
+            ))
+    }
+}
+
+impl<E: Ord> PartialOrd for Timestamped<E> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl<E> Timestamped<E> {
@@ -19,6 +80,7 @@ impl<E> Timestamped<E> {
         Timestamped {
             timestamp: self.timestamp,
             within_device_events_index: self.within_device_events_index,
+            timezone: self.timezone,
             event: f(self.event),
         }
     }
@@ -27,6 +89,7 @@ impl<E> Timestamped<E> {
         Timestamped {
             timestamp: self.timestamp,
             within_device_events_index: self.within_device_events_index,
+            timezone: self.timezone,
             event: &self.event,
         }
     }
@@ -35,6 +98,7 @@ impl<E> Timestamped<E> {
         Timestamped {
             timestamp: self.timestamp,
             within_device_events_index: self.within_device_events_index,
+            timezone: self.timezone,
             event: f(&self.event),
         }
     }
@@ -46,11 +110,13 @@ impl<E, Error> Timestamped<Result<E, Error>> {
             event,
             timestamp,
             within_device_events_index,
+            timezone,
         } = self;
         event.map(|event| Timestamped {
             event,
             timestamp,
             within_device_events_index,
+            timezone,
         })
     }
 }
@@ -67,6 +133,7 @@ impl<E: crate::Event> crate::Event for Timestamped<E> {
         E::from_versioned(&versioned.event, context).map(|event| Timestamped {
             timestamp: versioned.timestamp,
             within_device_events_index: versioned.within_device_events_index,
+            timezone: versioned.timezone,
             event,
         })
     }

--- a/libraries/weapon/src/data_model/4-event-stream-store.rs
+++ b/libraries/weapon/src/data_model/4-event-stream-store.rs
@@ -188,6 +188,7 @@ where
                 event: EventType::User(versioned_event),
                 timestamp,
                 within_device_events_index,
+                timezone,
             } => {
                 // Convert from versioned, passing context
                 if let Some(current_event) = E::from_versioned(versioned_event, context) {
@@ -195,6 +196,7 @@ where
                         event: current_event,
                         timestamp: *timestamp,
                         within_device_events_index: *within_device_events_index,
+                        timezone: *timezone,
                     };
                     state = A::process_event(state, context, &timestamped);
                 }

--- a/libraries/weapon/src/data_model/7-event-store.rs
+++ b/libraries/weapon/src/data_model/7-event-store.rs
@@ -295,22 +295,30 @@ impl<Stream: Eq + Hash + Clone + Ord, Device: Eq + Hash + Clone + Ord + 'static>
 impl<Stream: Eq + Hash + Clone + Ord, Device: Eq + Hash + Clone + Ord + 'static>
     EventStore<Stream, Device>
 {
-    /// Add a raw event (not timestamped). The event is automatically timestamped and
-    /// converted to its versioned form for storage.
+    /// Add a raw event (not timestamped). The event is automatically timestamped (with the
+    /// current time and the given `timezone`) and converted to its versioned form for storage.
     pub fn add_raw_event<Event>(
         &mut self,
         stream: Stream,
         device: Device,
         event: Event,
         modifier: Option<ListenerKey>,
+        timezone: chrono::FixedOffset,
     ) where
         Event: Ord + Clone + crate::Event + 'static,
         Event::Versioned: serde::Serialize + serde::de::DeserializeOwned + 'static,
     {
-        self.add_raw_event_at(stream, device, event, modifier, chrono::Utc::now());
+        self.add_raw_event_at(
+            stream,
+            device,
+            event,
+            modifier,
+            chrono::Utc::now(),
+            timezone,
+        );
     }
 
-    /// Add a raw event with a specific timestamp.
+    /// Add a raw event with a specific timestamp and timezone.
     pub fn add_raw_event_at<Event>(
         &mut self,
         stream: Stream,
@@ -318,6 +326,7 @@ impl<Stream: Eq + Hash + Clone + Ord, Device: Eq + Hash + Clone + Ord + 'static>
         event: Event,
         modifier: Option<ListenerKey>,
         timestamp: chrono::DateTime<chrono::Utc>,
+        timezone: chrono::FixedOffset,
     ) where
         Event: Ord + Clone + crate::Event + 'static,
         Event::Versioned: serde::Serialize + serde::de::DeserializeOwned + 'static,
@@ -331,6 +340,7 @@ impl<Stream: Eq + Hash + Clone + Ord, Device: Eq + Hash + Clone + Ord + 'static>
             event: EventType::User(event.to_versioned()),
             timestamp,
             within_device_events_index,
+            timezone,
         };
 
         self.add_device_event(stream, device, versioned_event, modifier);

--- a/libraries/weapon/src/data_model/7-event-store.rs
+++ b/libraries/weapon/src/data_model/7-event-store.rs
@@ -340,7 +340,7 @@ impl<Stream: Eq + Hash + Clone + Ord, Device: Eq + Hash + Clone + Ord + 'static>
             event: EventType::User(event.to_versioned()),
             timestamp,
             within_device_events_index,
-            timezone,
+            timezone: Some(timezone),
         };
 
         self.add_device_event(stream, device, versioned_event, modifier);

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -531,6 +531,7 @@ impl Weapon {
             self.device_id.clone(),
             event,
             None,
+            utils::current_local_offset(),
         );
         self.flush_notifications();
     }
@@ -546,6 +547,7 @@ impl Weapon {
             event,
             None,
             timestamp,
+            utils::current_local_offset(),
         );
         self.flush_notifications();
     }
@@ -556,6 +558,7 @@ impl Weapon {
             self.device_id.clone(),
             event,
             None,
+            utils::current_local_offset(),
         );
         self.flush_notifications();
     }
@@ -1092,7 +1095,12 @@ impl weapon::AppState for Deck {
             event,
             timestamp,
             within_device_events_index: _,
+            timezone,
         } = event;
+        // Bucket this event by the user's local day *at the time it was created*, using the
+        // timezone recorded on the event. This is more accurate than the current timezone for
+        // historical events (e.g. ones synced from another device or another locale).
+        let timezone = *timezone;
 
         let DeckEvent::Language(LanguageEvent {
             target_language: event_language,
@@ -1114,7 +1122,7 @@ impl weapon::AppState for Deck {
             // Clear accomplishment on each review
             deck.accomplishment = None;
 
-            let day = timestamp.with_timezone(&context.timezone).date_naive();
+            let day = timestamp.with_timezone(&timezone).date_naive();
             let time_before = deck
                 .stats
                 .today
@@ -1122,7 +1130,7 @@ impl weapon::AppState for Deck {
                 .filter(|t| t.day == day)
                 .map_or(0, |t| t.time_spent_seconds);
 
-            deck.update_daily_activity(timestamp, &context.timezone);
+            deck.update_daily_activity(timestamp, &timezone);
             deck.stats.total_reviews += 1;
 
             // Check if the user just crossed their daily study goal
@@ -1148,7 +1156,7 @@ impl weapon::AppState for Deck {
             LanguageEventContent::TranslationChallenge { .. }
             | LanguageEventContent::TranscriptionChallenge { .. } => {
                 let days_since_epoch = timestamp
-                    .with_timezone(&context.timezone)
+                    .with_timezone(&timezone)
                     .date_naive()
                     .num_days_from_ce() as i64;
                 *deck
@@ -4933,6 +4941,7 @@ mod tests {
             let ts = weapon::data_model::Timestamped {
                 timestamp: chrono::Utc::now(),
                 within_device_events_index: 0,
+                timezone: deck.context.timezone,
                 event,
             };
             let context = deck.context.clone();
@@ -5051,6 +5060,7 @@ mod tests {
         let timestamped = Timestamped {
             timestamp: chrono::Utc::now(),
             within_device_events_index: 0,
+            timezone: deck.context.timezone,
             event,
         };
         let context = deck.context.clone();
@@ -5245,6 +5255,7 @@ mod tests {
         let timestamped = Timestamped {
             timestamp: chrono::Utc::now(),
             within_device_events_index: 0,
+            timezone: context.timezone,
             event,
         };
 
@@ -5297,6 +5308,7 @@ mod tests {
             let timestamped = Timestamped {
                 timestamp: chrono::Utc::now(),
                 within_device_events_index: 0,
+                timezone: deck.context.timezone,
                 event,
             };
 

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -1099,8 +1099,10 @@ impl weapon::AppState for Deck {
         } = event;
         // Bucket this event by the user's local day *at the time it was created*, using the
         // timezone recorded on the event. This is more accurate than the current timezone for
-        // historical events (e.g. ones synced from another device or another locale).
-        let timezone = *timezone;
+        // historical events (e.g. ones synced from another device or another locale). Events
+        // recorded before timezones existed have no offset; fall back to the deck's current
+        // timezone for those, preserving the pre-timezone bucketing of already-persisted history.
+        let timezone = timezone.unwrap_or(context.timezone);
 
         let DeckEvent::Language(LanguageEvent {
             target_language: event_language,
@@ -4941,7 +4943,7 @@ mod tests {
             let ts = weapon::data_model::Timestamped {
                 timestamp: chrono::Utc::now(),
                 within_device_events_index: 0,
-                timezone: deck.context.timezone,
+                timezone: Some(deck.context.timezone),
                 event,
             };
             let context = deck.context.clone();
@@ -5060,7 +5062,7 @@ mod tests {
         let timestamped = Timestamped {
             timestamp: chrono::Utc::now(),
             within_device_events_index: 0,
-            timezone: deck.context.timezone,
+            timezone: Some(deck.context.timezone),
             event,
         };
         let context = deck.context.clone();
@@ -5255,7 +5257,7 @@ mod tests {
         let timestamped = Timestamped {
             timestamp: chrono::Utc::now(),
             within_device_events_index: 0,
-            timezone: context.timezone,
+            timezone: Some(context.timezone),
             event,
         };
 
@@ -5308,7 +5310,7 @@ mod tests {
             let timestamped = Timestamped {
                 timestamp: chrono::Utc::now(),
                 within_device_events_index: 0,
-                timezone: deck.context.timezone,
+                timezone: Some(deck.context.timezone),
                 event,
             };
 

--- a/yap-frontend-rs/src/simulation.rs
+++ b/yap-frontend-rs/src/simulation.rs
@@ -77,7 +77,7 @@ impl DayChallengeIterator {
             let ts = Timestamped {
                 timestamp: self.current_time,
                 within_device_events_index: self.event_index,
-                timezone: deck.context.timezone,
+                timezone: Some(deck.context.timezone),
                 event,
             };
             deck = apply_event(deck, &ts);
@@ -165,7 +165,7 @@ impl Iterator for DayChallengeIterator {
                 let ts = Timestamped {
                     timestamp: self.current_time,
                     within_device_events_index: self.event_index,
-                    timezone: self.deck().context.timezone,
+                    timezone: Some(self.deck().context.timezone),
                     event,
                 };
                 let deck = self.take_deck();

--- a/yap-frontend-rs/src/simulation.rs
+++ b/yap-frontend-rs/src/simulation.rs
@@ -77,6 +77,7 @@ impl DayChallengeIterator {
             let ts = Timestamped {
                 timestamp: self.current_time,
                 within_device_events_index: self.event_index,
+                timezone: deck.context.timezone,
                 event,
             };
             deck = apply_event(deck, &ts);
@@ -164,6 +165,7 @@ impl Iterator for DayChallengeIterator {
                 let ts = Timestamped {
                     timestamp: self.current_time,
                     within_device_events_index: self.event_index,
+                    timezone: self.deck().context.timezone,
                     event,
                 };
                 let deck = self.take_deck();

--- a/yap-frontend-rs/src/utils.rs
+++ b/yap-frontend-rs/src/utils.rs
@@ -93,6 +93,25 @@ impl Drop for PerfTimer {
     }
 }
 
+/// The user's current local timezone offset from UTC, as a `chrono::FixedOffset`.
+///
+/// On wasm, this reads the browser's timezone via `js_sys::Date::getTimezoneOffset`, which
+/// returns minutes that are positive when local time is *behind* UTC. Off-wasm (tests, native
+/// tooling) it falls back to UTC.
+pub fn current_local_offset() -> chrono::FixedOffset {
+    #[cfg(target_arch = "wasm32")]
+    let offset_seconds = {
+        // getTimezoneOffset() is minutes and positive when local is behind UTC.
+        let offset_minutes = js_sys::Date::new_0().get_timezone_offset();
+        (-offset_minutes * 60.0) as i32
+    };
+    #[cfg(not(target_arch = "wasm32"))]
+    let offset_seconds = 0;
+
+    chrono::FixedOffset::east_opt(offset_seconds)
+        .unwrap_or_else(|| chrono::FixedOffset::east_opt(0).expect("UTC offset is always valid"))
+}
+
 pub fn set_panic_hook() {
     // When the `console_error_panic_hook` feature is enabled, we can call the
     // `set_panic_hook` function at least once during initialization, and then


### PR DESCRIPTION
## Summary

Implements the Linear ticket: *Add timezone information to all event timestamps*.

Every event already records a UTC `timestamp`. This PR additionally records the **user's timezone (offset from UTC) at the moment the event was created**, so we can reason about local time-of-day, streaks, and behavior patterns without losing information to UTC normalization.

## What changed

- **`Timestamped<E>`** (`libraries/weapon/.../3-timestamped.rs`) gains a `timezone: chrono::FixedOffset` field.
  - Serialized to disk as offset **seconds** (`i32`) via a small serde helper — `FixedOffset` has no usable `Serialize`/`Ord` impls.
  - **Backwards compatible**: events serialized before this field existed deserialize to UTC via `#[serde(default)]`. (This is the one place we must preserve compatibility, since these are persisted/synced.)
  - `Ord`/`PartialOrd` are implemented manually and **intentionally ignore** `timezone`, preserving the prior `(timestamp, within_device_events_index, event)` ordering.
  - For WASM/TS, the field is typed as `number` (offset seconds) to match the JSON.
- **`add_raw_event` / `add_raw_event_at`** now take the offset and store it. The WASM layer derives the current local offset from the browser (`js_sys::Date`) via a new `utils::current_local_offset()` helper; native/test builds fall back to UTC. No TS call sites needed changes.
- **`process_event`** now buckets each event into its local day using the **event's recorded timezone** rather than the deck's current timezone — more accurate for historical/synced events. "Today"-style accessors still use the live context timezone.
- Updated all `Timestamped { .. }` construction sites (frontend tests, simulation harness, `course-spot-check`).

## Testing

- `cargo build`, `cargo clippy --all-targets`, `cargo fmt` — clean
- `cargo test -p weapon -p yap-frontend-rs` — all pass (incl. deterministic simulation tests)
- `cd yap-frontend-rs && wasm-pack build --features local-backend` — builds; verified generated `Timestamped.timezone?: number`
