### PR TITLE
Fix panic-prone f64 sort in notification scheduling

### DIFF
--- a/yap-frontend-rs/src/notifications.rs
+++ b/yap-frontend-rs/src/notifications.rs
@@ -228,7 +228,7 @@ impl Deck {
         }
 
         // Remove duplicate notifications at the same time
-        notifications.sort_by(|a, b| a.scheduled_at.partial_cmp(&b.scheduled_at).unwrap());
+        notifications.sort_by(|a, b| a.scheduled_at.total_cmp(&b.scheduled_at));
         notifications.dedup_by(|a, b| (a.scheduled_at - b.scheduled_at).abs() < 60000.0); // Within 1 minute
 
         notifications


### PR DESCRIPTION
## Summary

- Replace `partial_cmp(...).unwrap()` with `total_cmp(...)` when sorting scheduled notifications by timestamp

## Details

`f64::partial_cmp` returns `None` for NaN values, so calling `.unwrap()` on it will panic if either `scheduled_at` is NaN. `f64::total_cmp` handles all float values (including NaN) without panicking and has the same behavior for normal finite floats.

In practice `scheduled_at` is always derived from `i64` timestamps (which can't be NaN when cast to f64), but if a `ScheduledNotification` were ever deserialized from stored data with a NaN timestamp, the old code would panic inside the WASM module.

**Note:** The Sentry MCP server didn't connect during this run, so this fix is based on static code analysis rather than observed production errors. All other `unwrap()` calls in the production WASM/backend code were verified to be either in test functions, parsing compile-time embedded data, or protected by logical invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AT53rBgrHK1jtK3J9i5439

---
_Generated by [Claude Code](https://claude.ai/code/session_01AT53rBgrHK1jtK3J9i5439)_