### PR TITLE
reset-password: catch unexpected setSession rejections

### DIFF
--- a/yap-frontend/src/pages/reset-password.tsx
+++ b/yap-frontend/src/pages/reset-password.tsx
@@ -55,6 +55,11 @@ export function ResetPassword() {
             // Clear the URL to hide the tokens
             window.history.replaceState(null, "", window.location.pathname);
           }
+        })
+        .catch((e) => {
+          console.error("Unexpected error setting session:", e);
+          setError("Invalid or expired reset link. Please request a new one.");
+          setIsValidToken(false);
         });
     } else {
       console.log("No tokens found in URL");


### PR DESCRIPTION
Adds a `.catch()` to the `supabase.auth.setSession()` promise chain in `reset-password.tsx`. Without it, an unexpected rejection becomes an unhandled promise rejection instead of showing the user an error message.

> Note: the original PR also fixed the `todo!()` panics in the backend TTS handlers, but those landed via #113. The branch was rebuilt on current main with just the remaining fix.