### PR TITLE
rename: get_cached -> get_or_evict_cached

### DIFF
--- a/yap-frontend-rs/src/audio.rs
+++ b/yap-frontend-rs/src/audio.rs
@@ -45,7 +45,7 @@ impl AudioCache {
         Ok(Self { audio_dir })
     }
 
-    pub async fn get_cached(
+    pub async fn get_or_evict_cached(
         &self,
         request: &TtsRequest,
         provider: &TtsProvider,
@@ -148,7 +148,7 @@ impl AudioCache {
         }
 
         // Check cache first
-        if let Some(cached_bytes) = self.get_cached(request, provider).await {
+        if let Some(cached_bytes) = self.get_or_evict_cached(request, provider).await {
             return Ok(FetchedAudio {
                 bytes: cached_bytes,
                 voice_actor: None,


### PR DESCRIPTION
## Why the old name was misleading

`AudioCache::get_cached` follows the Rust convention of a pure, read-only accessor — callers reading `self.get_cached(request, provider).await` would naturally assume it only performs a lookup. In reality the function **deletes OPFS files** when it discovers an invalid or unreadable cached entry. That silent destructive side effect directly contradicts the mental model that `get_*` names establish.

## What the new name conveys

`get_or_evict_cached` makes the dual behaviour explicit: the function either returns the valid cached bytes, or evicts the corrupt/unreadable file from OPFS and returns `None`. A caller seeing `get_or_evict_cached` immediately knows the call may write to the filesystem.

## Before / After

```rust
// Before — looks like a pure read:
if let Some(bytes) = self.get_cached(request, provider).await { … }

// After — side-effect is visible at the call site:
if let Some(bytes) = self.get_or_evict_cached(request, provider).await { … }
```

## Verification

- Updated definition (`audio.rs:48`) and its single call site (`audio.rs:151`).
- Confirmed no remaining references with `grep -r '\.get_cached\b' --include='*.rs'`.
- `cargo fmt` ran clean.
- Note: `cargo check` cannot complete in this environment because a git dependency (`tysm`, used only by `yap-ai-backend`) is unreachable through the network proxy — this is a pre-existing infrastructure issue unrelated to the rename. CI will verify the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZtV543qq8TAB3zBbJyVTS

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZtV543qq8TAB3zBbJyVTS)_