### PR TITLE
fix: resolve unhandled exceptions from duplicate effects and todo panics

### DIFF
--- a/yap-ai-backend/src/main.rs
+++ b/yap-ai-backend/src/main.rs
@@ -237,7 +237,7 @@ async fn text_to_speech(
         Language::Japanese => "GxhGYQesaQaYKePCZDEC", // Japanese voice
         Language::Hindi => "K24eC7JpUgk8zMtQYrpV",  // Hindi voice
 
-        Language::Chinese => todo!(),
+        Language::Chinese => return Err(StatusCode::NOT_IMPLEMENTED),
     };
     let url = format!("https://api.elevenlabs.io/v1/text-to-speech/{voice_id}");
 
@@ -289,7 +289,7 @@ async fn google_text_to_speech(
         Language::Japanese => ("ja-JP", "ja-JP-Chirp3-HD-Achernar"),
         Language::Hindi => ("hi-IN", "hi-IN-Chirp3-HD-Achernar"),
 
-        Language::Chinese => todo!(),
+        Language::Chinese => return Err(StatusCode::NOT_IMPLEMENTED),
     };
 
     let client = google_tts::GoogleTtsClient::new(google_api_key);

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -889,44 +889,6 @@ function Review({
   ]);
 
   useEffect(() => {
-    if (!currentChallenge) {
-      setBannedChallengeTypes(computeBannedChallengeTypes());
-    }
-  }, [currentChallenge, computeBannedChallengeTypes]);
-
-  useEffect(() => {
-    if (currentChallenge) return;
-    const timeouts: ReturnType<typeof setTimeout>[] = [];
-
-    const scheduleRefresh = (storageKey: string) => {
-      const timestamp = localStorage.getItem(storageKey);
-      if (!timestamp) return;
-      const elapsed = Date.now() - parseInt(timestamp);
-      const remaining = CANT_LISTEN_DURATION_MS - elapsed;
-
-      if (remaining > 0) {
-        timeouts.push(
-          setTimeout(() => {
-            setBannedChallengeTypes(computeBannedChallengeTypes());
-          }, remaining),
-        );
-      } else {
-        setBannedChallengeTypes(computeBannedChallengeTypes());
-      }
-    };
-
-    scheduleRefresh("yap-cant-listen-timestamp");
-    scheduleRefresh("yap-cant-speak-timestamp");
-
-    return () => timeouts.forEach((timeout) => clearTimeout(timeout));
-  }, [
-    currentChallenge,
-    bannedChallengeTypes,
-    CANT_LISTEN_DURATION_MS,
-    computeBannedChallengeTypes,
-  ]);
-
-  useEffect(() => {
     const abortController = new AbortController();
 
     deck.cache_challenge_audio(accessToken, abortController.signal);

--- a/yap-frontend/src/components/challenges/TranslationChallenge.tsx
+++ b/yap-frontend/src/components/challenges/TranslationChallenge.tsx
@@ -687,7 +687,7 @@ export function TranslationChallenge({
     return getMovieMetadata(deck, movieIds);
   }, [sentence.movie_titles, deck]);
   const [correctTranslation, setCorrectTranslation] = useState(
-    sentence.native_translations[0],
+    sentence.native_translations[0] ?? "",
   );
   const [selectedPhraseIndex, setSelectedPhraseIndex] = useState<number>(-1);
   const [showReportModal, setShowReportModal] = useState(false);
@@ -963,7 +963,7 @@ export function TranslationChallenge({
           userTranslation,
           sentence.native_translations,
           nativeLanguage,
-        ) ?? sentence.native_translations[0];
+        ) ?? sentence.native_translations[0] ?? "";
       setCorrectTranslation(closest);
       const generation = ++gradingGenerationRef.current;
       setGrade({ grading: null });


### PR DESCRIPTION
## Summary

Three unambiguous bugs found by code inspection (Sentry MCP wasn't available in this session):

- **Duplicate `useEffect` pair in `Review` (App.tsx)**: Two identical effect pairs were copy-pasted — one that recomputes `bannedChallengeTypes` when `currentChallenge` clears, and one that schedules timeout refreshes for the "can't listen/speak" timers. The duplicate caused double state updates and leaked timers every time those effects fired.

- **`todo!()` panics in backend TTS handlers**: `text_to_speech` (ElevenLabs) and `google_text_to_speech` both had `Language::Chinese => todo!()` arms. A request for Chinese TTS — whether from a future course or a manually crafted API call — would panic the Fly.io process and take down the server. Replaced with `return Err(StatusCode::NOT_IMPLEMENTED)`.

- **`native_translations[0]` without bounds check (TranslationChallenge)**: Used as initial `useState` value and as a `??` fallback in `handleCheckAnswer`. If the translations array were ever empty, this yields `undefined` where a `string` is expected, causing a render crash. Added `?? ""` guard in both spots.

## Test plan

- [ ] Open the review page with cant-listen/cant-speak active and verify the UI unblocks correctly after 15 min (or by clearing localStorage) — previously this would fire twice
- [ ] Verify the backend still builds and deploys (`cargo build --release -p yap-ai-backend`)
- [ ] Verify no TypeScript errors on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDgLxay3Xxg5wdKd4Gqu9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDgLxay3Xxg5wdKd4Gqu9Z)_