### PR TITLE
Review lockup: soft daily review cap (trigger >20 due, keep 15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,5 +126,6 @@ cd supabase && supabase start
 - Use `uv` for Python dependency management in NLP components
 - Use `pnpm` for JavaScript/TypeScript dependencies
 - All target-language text in yap-frontend should use the TargetLanguage component 
+- For spacing between siblings in yap-frontend, prefer parent-driven spacing — Tailwind `gap-*` on a flex/grid parent (e.g. the Card component's gap) or a `space-y-*` wrapper — over per-child margins. Keep spacing uniform at the container level.
 
 Final most important note: We do not have to worry about backwards compatibility with respect to our API. We mostly only have to worry about it for our events, in yap-frontend-rs/src/deck_event, as those types are serialized to disk. We do not worry about it with our API. Rust functions, traits, structs... except for those implicated by yap-frontend-rs/src/deck_event, do not worry! All the code is here, it's basically a monorepo, so we can always fix all the breakage and that's always better than leaving scar tissue from old code. If that makes sense to you, please start conversations by saying "I will maintain backwards compatibility with regards to our structs that get serialized, but make all the changes necessary across the codebase to write clean and minimal code without worrying about backwards compatibility in our internal APIs."

--- a/yap-frontend-rs/src/deck_event/current.rs
+++ b/yap-frontend-rs/src/deck_event/current.rs
@@ -231,6 +231,16 @@ pub enum LanguageEventContent {
     SetDailyReviewTarget {
         daily_review_target: DailyReviewTarget,
     },
+    /// Lock up every card that is due at this event's timestamp, EXCEPT the
+    /// listed cards. Locked cards are hidden from the review queue until
+    /// released via `UnlockCards`.
+    LockDueCardsExcept {
+        keep: Vec<CardIndicator<Gram<String>, String>>,
+    },
+    /// Release the listed cards from lockup.
+    UnlockCards {
+        cards: Vec<CardIndicator<Gram<String>, String>>,
+    },
 }
 
 #[derive(PartialEq, Eq, Ord, PartialOrd, Default, Clone, Debug)]

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -2562,6 +2562,14 @@ impl Deck {
         });
         locked.truncate(REVIEW_LOCKUP_KEEP);
 
+        let release_preview = locked
+            .iter()
+            .filter_map(|card| {
+                self.cards
+                    .get(card)
+                    .and_then(|card_data| self.card_to_summary(card, card_data))
+            })
+            .collect();
         let unlock_event = DeckEvent::Language(LanguageEvent {
             target_language: self.context.course.target_language,
             native_language: self.context.course.native_language,
@@ -2578,7 +2586,7 @@ impl Deck {
             },
         });
         Some(ReleaseOffer {
-            release_count: locked.len(),
+            release_preview,
             unlock_event,
         })
     }
@@ -4192,15 +4200,21 @@ impl LockupOffer {
 /// The "Review N more cards" offer that releases cards from lockup.
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub struct ReleaseOffer {
-    release_count: usize,
+    release_preview: Vec<CardSummary>,
     unlock_event: DeckEvent,
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 impl ReleaseOffer {
+    /// The cards that would be released — exactly what the user is shown.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn release_preview(&self) -> Vec<CardSummary> {
+        self.release_preview.clone()
+    }
+
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn release_count(&self) -> usize {
-        self.release_count
+        self.release_preview.len()
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -49,7 +49,7 @@ use lasso::Spur;
 use opfs::persistent::{self};
 use pav_regression::{IsotonicRegression, Point, SmoothRegression, UnitWeight};
 use rs_fsrs::FSRS;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -1016,6 +1016,10 @@ pub struct DeckState {
     accomplishment: Option<Accomplishment>,
     /// The user's daily study intensity
     daily_review_target: DailyReviewTarget,
+    /// Cards set aside ("locked up") and hidden from the review queue
+    locked_cards: FxHashSet<CardIndicator<SpurGram, Spur>>,
+    /// The user's local day of the most recent LockDueCardsExcept event
+    last_lock_day: Option<chrono::NaiveDate>,
 }
 
 #[derive(Clone, Debug)]
@@ -1036,6 +1040,10 @@ pub struct Deck {
     accomplishment: Option<Accomplishment>,
     /// The user's daily study intensity
     daily_review_target: DailyReviewTarget,
+    /// Cards set aside ("locked up") and hidden from the review queue
+    locked_cards: FxHashSet<CardIndicator<SpurGram, Spur>>,
+    /// The user's local day of the most recent LockDueCardsExcept event
+    last_lock_day: Option<chrono::NaiveDate>,
 }
 
 #[derive(Clone, Debug)]
@@ -1078,6 +1086,8 @@ impl From<Deck> for DeckState {
             sentence_list: deck.sentence_list,
             accomplishment: deck.accomplishment,
             daily_review_target: deck.daily_review_target,
+            locked_cards: deck.locked_cards,
+            last_lock_day: deck.last_lock_day,
         }
     }
 }
@@ -1119,6 +1129,8 @@ impl weapon::AppState for Deck {
             event,
             LanguageEventContent::SetSentenceList { .. }
                 | LanguageEventContent::SetDailyReviewTarget { .. }
+                | LanguageEventContent::LockDueCardsExcept { .. }
+                | LanguageEventContent::UnlockCards { .. }
         );
         if counts_as_review_activity {
             // Clear accomplishment on each review
@@ -1230,6 +1242,10 @@ impl weapon::AppState for Deck {
                             .entry(flashcard_type)
                             .or_insert(0) += 1;
                     }
+
+                    // A card being actively reviewed (e.g. from another device)
+                    // is self-evidently not set aside
+                    deck.locked_cards.remove(&reviewed);
 
                     deck.log_review(reviewed, *rating, *timestamp, context);
                 }
@@ -1699,6 +1715,36 @@ impl weapon::AppState for Deck {
             } => {
                 deck.daily_review_target = daily_review_target.clone();
             }
+            LanguageEventContent::LockDueCardsExcept { keep } => {
+                let keep: FxHashSet<_> = keep
+                    .iter()
+                    .filter_map(|card| {
+                        card.get_interned(
+                            &context.language_pack.string_rodeo,
+                            &context.language_pack.gram_rodeo,
+                        )
+                    })
+                    .collect();
+                for (card, card_data) in deck.cards.iter() {
+                    if let CardData::Added { fsrs_card } = card_data
+                        && fsrs_card.due <= *timestamp
+                        && !keep.contains(card)
+                    {
+                        deck.locked_cards.insert(*card);
+                    }
+                }
+                deck.last_lock_day = Some(timestamp.with_timezone(&timezone).date_naive());
+            }
+            LanguageEventContent::UnlockCards { cards } => {
+                for card in cards {
+                    if let Some(card) = card.get_interned(
+                        &context.language_pack.string_rodeo,
+                        &context.language_pack.gram_rodeo,
+                    ) {
+                        deck.locked_cards.remove(&card);
+                    }
+                }
+            }
         }
 
         deck.sync_past_days();
@@ -1892,6 +1938,8 @@ impl weapon::AppState for Deck {
             sentence_list: state.sentence_list,
             accomplishment: state.accomplishment,
             daily_review_target: state.daily_review_target,
+            locked_cards: state.locked_cards,
+            last_lock_day: state.last_lock_day,
         }
     }
 }
@@ -1930,6 +1978,8 @@ impl DeckState {
             sentence_list: None,
             accomplishment: None,
             daily_review_target: DailyReviewTarget::Regular,
+            locked_cards: FxHashSet::default(),
+            last_lock_day: None,
         }
     }
 
@@ -2364,11 +2414,28 @@ impl Deck {
         banned_challenge_types: Vec<ChallengeRequirements>,
         timestamp_ms: f64,
     ) -> ReviewInfo {
+        self.get_review_info_impl(banned_challenge_types, timestamp_ms, false)
+    }
+
+    /// Like `get_review_info`, but treats locked cards as due. Used by the
+    /// simulation so long-range projections aren't skewed by cards frozen in
+    /// lockup.
+    pub(crate) fn get_review_info_including_locked(&self, timestamp_ms: f64) -> ReviewInfo {
+        self.get_review_info_impl(vec![], timestamp_ms, true)
+    }
+
+    fn get_review_info_impl(
+        &self,
+        banned_challenge_types: Vec<ChallengeRequirements>,
+        timestamp_ms: f64,
+        include_locked: bool,
+    ) -> ReviewInfo {
         let now =
             DateTime::<Utc>::from_timestamp_millis(timestamp_ms as i64).unwrap_or_else(Utc::now);
         let mut due_cards = vec![];
         let mut future_cards = vec![];
         let mut due_but_banned_cards = vec![];
+        let mut due_but_locked_cards = vec![];
 
         let no_listening_cards = banned_challenge_types.contains(&ChallengeRequirements::Listening);
         let no_text_cards = banned_challenge_types.contains(&ChallengeRequirements::Text);
@@ -2379,6 +2446,10 @@ impl Deck {
                 let due_date = fsrs_card.due;
 
                 if due_date <= now {
+                    if !include_locked && self.locked_cards.contains(card) {
+                        due_but_locked_cards.push(*card);
+                        continue;
+                    }
                     match card.card_type().challenge_type() {
                         ChallengeRequirements::Text if no_text_cards => {
                             due_but_banned_cards.push(*card);
@@ -2398,29 +2469,118 @@ impl Deck {
         }
 
         // sort by due date, then by card indicator for deterministic ordering
-        due_cards.sort_by_key(|card_indicator| {
+        let sort_key = |card_indicator: &CardIndicator<SpurGram, Spur>| {
             let card_data = self.cards.get(card_indicator).unwrap();
             let due_timestamp = ordered_float::NotNan::new(card_data.due_timestamp_ms()).unwrap();
             (due_timestamp, *card_indicator)
-        });
-
-        due_but_banned_cards.sort_by_key(|card_indicator| {
-            let card_data = self.cards.get(card_indicator).unwrap();
-            let due_timestamp = ordered_float::NotNan::new(card_data.due_timestamp_ms()).unwrap();
-            (due_timestamp, *card_indicator)
-        });
-
-        future_cards.sort_by_key(|card_indicator| {
-            let card_data = self.cards.get(card_indicator).unwrap();
-            let due_timestamp = ordered_float::NotNan::new(card_data.due_timestamp_ms()).unwrap();
-            (due_timestamp, *card_indicator)
-        });
+        };
+        due_cards.sort_by_key(sort_key);
+        due_but_banned_cards.sort_by_key(sort_key);
+        due_but_locked_cards.sort_by_key(sort_key);
+        future_cards.sort_by_key(sort_key);
 
         ReviewInfo {
             due_cards,
             due_but_banned_cards,
+            due_but_locked_cards,
             future_cards,
         }
+    }
+
+    /// How many cards are currently set aside in lockup.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+    pub fn locked_count(&self) -> usize {
+        self.locked_cards.len()
+    }
+
+    /// The daily lockup offer ("Let's review these 15 cards today").
+    /// Non-None when more than `REVIEW_LOCKUP_TRIGGER` cards are due and the
+    /// user hasn't locked up yet today; keeps the `REVIEW_LOCKUP_KEEP`
+    /// most-due cards active and sets the rest aside.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+    pub fn get_lockup_offer(
+        &self,
+        banned_challenge_types: Vec<ChallengeRequirements>,
+        timestamp_ms: f64,
+    ) -> Option<LockupOffer> {
+        let now =
+            DateTime::<Utc>::from_timestamp_millis(timestamp_ms as i64).unwrap_or_else(Utc::now);
+        // At most one lockup per local day
+        let today = now.with_timezone(&self.context.timezone).date_naive();
+        if self.last_lock_day == Some(today) {
+            return None;
+        }
+
+        let review_info = self.get_review_info(banned_challenge_types, timestamp_ms);
+        if review_info.due_cards.len() <= REVIEW_LOCKUP_TRIGGER {
+            return None;
+        }
+
+        let keep = &review_info.due_cards[..REVIEW_LOCKUP_KEEP];
+        let keep_preview = keep
+            .iter()
+            .filter_map(|card| {
+                self.cards
+                    .get(card)
+                    .and_then(|card_data| self.card_to_summary(card, card_data))
+            })
+            .collect();
+        let lock_event = DeckEvent::Language(LanguageEvent {
+            target_language: self.context.course.target_language,
+            native_language: self.context.course.native_language,
+            content: LanguageEventContent::LockDueCardsExcept {
+                keep: keep
+                    .iter()
+                    .map(|card| {
+                        card.resolve(
+                            &self.context.language_pack.string_rodeo,
+                            &self.context.language_pack.gram_rodeo,
+                        )
+                    })
+                    .collect(),
+            },
+        });
+        Some(LockupOffer {
+            keep_preview,
+            lock_event,
+        })
+    }
+
+    /// The "Review N more cards" offer: releases the most-due locked cards.
+    /// None when nothing is locked.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+    pub fn get_release_offer(&self) -> Option<ReleaseOffer> {
+        if self.locked_cards.is_empty() {
+            return None;
+        }
+
+        let mut locked: Vec<_> = self.locked_cards.iter().copied().collect();
+        locked.sort_by_key(|card_indicator| {
+            let card_data = self.cards.get(card_indicator).unwrap();
+            let due_timestamp = ordered_float::NotNan::new(card_data.due_timestamp_ms()).unwrap();
+            (due_timestamp, *card_indicator)
+        });
+        locked.truncate(REVIEW_LOCKUP_KEEP);
+
+        let unlock_event = DeckEvent::Language(LanguageEvent {
+            target_language: self.context.course.target_language,
+            native_language: self.context.course.native_language,
+            content: LanguageEventContent::UnlockCards {
+                cards: locked
+                    .iter()
+                    .map(|card| {
+                        card.resolve(
+                            &self.context.language_pack.string_rodeo,
+                            &self.context.language_pack.gram_rodeo,
+                        )
+                    })
+                    .collect(),
+            },
+        });
+        Some(ReleaseOffer {
+            release_count: locked.len(),
+            unlock_event,
+        })
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
@@ -4002,11 +4162,59 @@ pub enum CardContent {
     },
 }
 
+/// Lockup ("set cards aside") is offered when more than this many cards are due...
+pub(crate) const REVIEW_LOCKUP_TRIGGER: usize = 20;
+/// ...and keeps this many of the most-due cards active. The gap between the
+/// two is a deliberate wiggle zone so the offer doesn't nag on borderline days.
+pub(crate) const REVIEW_LOCKUP_KEEP: usize = 15;
+
+/// The daily offer to set aside ("lock up") all but the most-due cards.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub struct LockupOffer {
+    keep_preview: Vec<CardSummary>,
+    lock_event: DeckEvent,
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl LockupOffer {
+    /// The cards that stay active — exactly what the user is shown and approves.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn keep_preview(&self) -> Vec<CardSummary> {
+        self.keep_preview.clone()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn lock_event(&self) -> DeckEvent {
+        self.lock_event.clone()
+    }
+}
+
+/// The "Review N more cards" offer that releases cards from lockup.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub struct ReleaseOffer {
+    release_count: usize,
+    unlock_event: DeckEvent,
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl ReleaseOffer {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn release_count(&self) -> usize {
+        self.release_count
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn unlock_event(&self) -> DeckEvent {
+        self.unlock_event.clone()
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[derive(Debug, Clone)]
 pub struct ReviewInfo {
     due_cards: Vec<CardIndicator<SpurGram, Spur>>,
     due_but_banned_cards: Vec<CardIndicator<SpurGram, Spur>>,
+    due_but_locked_cards: Vec<CardIndicator<SpurGram, Spur>>,
     future_cards: Vec<CardIndicator<SpurGram, Spur>>,
 }
 
@@ -4124,6 +4332,11 @@ impl ReviewInfo {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn due_but_locked_count(&self) -> usize {
+        self.due_but_locked_cards.len()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn future_count(&self) -> usize {
         self.future_cards.len()
     }
@@ -4135,6 +4348,7 @@ impl ReviewInfo {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[derive(Clone)]
 pub struct CardSummary {
     card_indicator: CardIndicator<Gram<String>, String>,
     due_timestamp_ms: f64,
@@ -4960,6 +5174,147 @@ mod tests {
         } else {
             println!("✓ No cards available to add (empty language pack)");
         }
+    }
+
+    fn apply_deck_event(deck: Deck, event: DeckEvent, timestamp: DateTime<Utc>) -> Deck {
+        let ts = weapon::data_model::Timestamped {
+            timestamp,
+            within_device_events_index: 0,
+            timezone: Some(deck.context.timezone),
+            event,
+        };
+        let context = deck.context.clone();
+        let state = DeckState::from(deck);
+        let state = <Deck as weapon::AppState>::process_event(state, &context, &ts);
+        <Deck as weapon::AppState>::finalize(state, &context)
+    }
+
+    /// Add exactly `n` valid written cards (due immediately) at `timestamp`.
+    fn deck_with_n_due_cards(n: usize, timestamp: DateTime<Utc>) -> Deck {
+        let deck = Deck::default();
+        let cards: Vec<_> = deck
+            .context
+            .language_pack
+            .gram_frequencies
+            .entries
+            .keys()
+            .map(|gram| CardIndicator::WrittenGram { gram: *gram })
+            .filter(|card| deck.context.is_card_valid(card))
+            .take(n)
+            .collect();
+        assert_eq!(cards.len(), n, "language pack has too few valid grams");
+        let event = deck.cards_to_event(&cards, &None).unwrap();
+        apply_deck_event(deck, event, timestamp)
+    }
+
+    #[test]
+    fn test_lockup_locks_due_complement_and_release_restores() {
+        use chrono::TimeZone;
+
+        let t0 = Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap();
+        let t1 = t0 + chrono::Duration::hours(1);
+        let deck = deck_with_n_due_cards(25, t0);
+        let t1_ms = t1.timestamp_millis() as f64;
+
+        let before = deck.get_review_info(vec![], t1_ms);
+        assert_eq!(before.due_count(), 25);
+        assert_eq!(before.due_but_locked_count(), 0);
+
+        let offer = deck
+            .get_lockup_offer(vec![], t1_ms)
+            .expect("offer expected");
+        let deck = apply_deck_event(deck, offer.lock_event(), t1);
+
+        assert_eq!(deck.locked_count(), 10);
+        let after = deck.get_review_info(vec![], t1_ms);
+        assert_eq!(after.due_count(), 15);
+        assert_eq!(after.due_but_locked_count(), 10);
+        // The kept cards are exactly the 15 most-due
+        assert_eq!(after.due_cards, before.due_cards[..15].to_vec());
+
+        // Locked cards are invisible to the queue but included for simulation
+        let simulated = deck.get_review_info_including_locked(t1_ms);
+        assert_eq!(simulated.due_count(), 25);
+        assert_eq!(simulated.due_but_locked_count(), 0);
+
+        // Release restores the most-due locked cards
+        let release = deck.get_release_offer().expect("release expected");
+        assert_eq!(release.release_count(), 10);
+        let deck = apply_deck_event(deck, release.unlock_event(), t1);
+        assert_eq!(deck.locked_count(), 0);
+        assert_eq!(deck.get_review_info(vec![], t1_ms).due_count(), 25);
+        assert!(deck.get_release_offer().is_none());
+    }
+
+    #[test]
+    fn test_lockup_offer_thresholds_and_once_per_day() {
+        use chrono::TimeZone;
+
+        let t0 = Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap();
+        let t1 = t0 + chrono::Duration::hours(1);
+        let t1_ms = t1.timestamp_millis() as f64;
+
+        // At exactly the trigger count there is no offer (wiggle zone)
+        let deck20 = deck_with_n_due_cards(20, t0);
+        assert!(deck20.get_lockup_offer(vec![], t1_ms).is_none());
+
+        // One past the trigger, the offer keeps 15
+        let deck = deck_with_n_due_cards(21, t0);
+        let offer = deck
+            .get_lockup_offer(vec![], t1_ms)
+            .expect("offer expected");
+        assert_eq!(offer.keep_preview().len(), 15);
+        let deck = apply_deck_event(deck, offer.lock_event(), t1);
+        assert_eq!(deck.locked_count(), 6);
+
+        // Even if the active queue grows past the trigger again on the same
+        // day (here: by releasing cards), there is at most one lockup per day
+        let deck40 = deck_with_n_due_cards(40, t0);
+        let offer = deck40
+            .get_lockup_offer(vec![], t1_ms)
+            .expect("offer expected");
+        let deck40 = apply_deck_event(deck40, offer.lock_event(), t1);
+        assert_eq!(deck40.locked_count(), 25);
+        let release = deck40.get_release_offer().expect("release expected");
+        assert_eq!(release.release_count(), 15);
+        let deck40 = apply_deck_event(deck40, release.unlock_event(), t1);
+        assert_eq!(deck40.get_review_info(vec![], t1_ms).due_count(), 30);
+        assert!(deck40.get_lockup_offer(vec![], t1_ms).is_none());
+
+        // The next local day, the offer returns
+        let t2 = t1 + chrono::Duration::days(1);
+        assert!(
+            deck40
+                .get_lockup_offer(vec![], t2.timestamp_millis() as f64)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn test_reviewing_a_locked_card_unlocks_it() {
+        use chrono::TimeZone;
+
+        let t0 = Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap();
+        let t1 = t0 + chrono::Duration::hours(1);
+        let t1_ms = t1.timestamp_millis() as f64;
+        let deck = deck_with_n_due_cards(25, t0);
+
+        let offer = deck
+            .get_lockup_offer(vec![], t1_ms)
+            .expect("offer expected");
+        let deck = apply_deck_event(deck, offer.lock_event(), t1);
+        assert_eq!(deck.locked_count(), 10);
+
+        // A review of a locked card (e.g. from another device) releases it
+        let locked_card = deck.get_review_info(vec![], t1_ms).due_but_locked_cards[0];
+        let resolved = locked_card.resolve(
+            &deck.context.language_pack.string_rodeo,
+            &deck.context.language_pack.gram_rodeo,
+        );
+        let event = deck.review_card(resolved, Rating::Good).unwrap();
+        let deck = apply_deck_event(deck, event, t1);
+        assert_eq!(deck.locked_count(), 9);
+        assert!(!deck.locked_cards.contains(&locked_card));
     }
 
     #[test]

--- a/yap-frontend-rs/src/simulation.rs
+++ b/yap-frontend-rs/src/simulation.rs
@@ -135,9 +135,10 @@ impl Iterator for DayChallengeIterator {
             return None;
         }
 
+        // Include locked cards so projections aren't skewed by cards frozen in lockup
         let review_info = self
             .deck()
-            .get_review_info(vec![], self.current_time.timestamp_millis() as f64);
+            .get_review_info_including_locked(self.current_time.timestamp_millis() as f64);
         if let Some(challenge) = review_info.get_next_challenge(self.deck()) {
             let to_return = challenge.clone();
             // Answer the challenge, marking new flashcards as forgotten once

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -431,7 +431,6 @@ function ReviewPage() {
         .with(
           { type: "deck", deck: P.not(P.nullish) },
           ({ deck, targetLanguage, nativeLanguage, startingFresh }) => {
-            const reviewInfo = deck.get_review_info([], Date.now());
             const totalReviewsCompleted = deck.get_total_reviews();
             const autoplayed = lastAutoPlayReviewCount == totalReviewsCompleted;
             const setAutoplayed = () =>
@@ -455,7 +454,6 @@ function ReviewPage() {
                     onChangeLanguage: () => navigate("/select-language"),
                     showSignupNag: deck !== null,
                     language: targetLanguage,
-                    dueCount: reviewInfo.due_count || 0,
                     dailyGoalPercent:
                       (deck.get_today_time_spent() / deck.get_daily_review_target()) * 100,
                   }}

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -1187,6 +1187,7 @@ function Review({
         ) : lockupOffer ? (
           <LockupOfferScreen
             offer={lockupOffer}
+            deck={deck}
             targetLanguage={targetLanguage}
             onAccept={addEvent}
           />

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -96,6 +96,7 @@ import { BackgroundShader } from "@/components/BackgroundShader";
 import { Movies } from "@/components/Movies";
 import { getMovieMetadata } from "@/lib/movie-cache";
 import { PlacementTest } from "@/components/PlacementTest";
+import { LockupOfferScreen } from "@/components/LockupOffer";
 
 // Essential user info to persist for offline functionality
 export interface UserInfo {
@@ -883,9 +884,14 @@ function Review({
     ChallengeRequirements[]
   >(() => computeBannedChallengeTypes());
 
-  const reviewInfo = useMemo(() => {
+  const { reviewInfo, lockupOffer } = useMemo(() => {
     const now = Date.now();
-    return deck.get_review_info(bannedChallengeTypes, now);
+    return {
+      reviewInfo: deck.get_review_info(bannedChallengeTypes, now),
+      // The daily lockup offer: when a review backlog builds up, keep the
+      // most-due cards active and set the rest aside
+      lockupOffer: deck.get_lockup_offer(bannedChallengeTypes, now),
+    };
     // cardsBecameDue is intentionally included to trigger recalculation when cards become due
   }, [deck, bannedChallengeTypes, cardsBecameDue]);
 
@@ -1177,6 +1183,12 @@ function Review({
               );
               weapon.add_deck_event(event);
             }}
+          />
+        ) : lockupOffer ? (
+          <LockupOfferScreen
+            offer={lockupOffer}
+            targetLanguage={targetLanguage}
+            onAccept={addEvent}
           />
         ) : shouldShowSetDisplayName ? (
           <SetDisplayName

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -42,45 +42,51 @@ export function LockupOfferScreen({
   }
 
   return (
-    <Card className="max-w w-full p-6 gap-4 select-none" animate>
-      <h2 className="text-xl font-semibold text-center">
-        Let's review these cards today
-      </h2>
+    <div className="space-y-4">
+      <Card className="max-w w-full p-6 gap-4 select-none" animate>
+        <h2 className="text-xl font-semibold text-center">
+          Let's review these cards today
+        </h2>
 
-      {CARD_GROUPS.map(({ type, label, showSubtitle }) => {
-        const cards = byType.get(type);
-        if (!cards || cards.length === 0) return null;
-        return (
-          <div key={type} className="space-y-2">
-            <p className="text-sm font-medium text-muted-foreground text-center">
-              {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
-            </p>
-            <div className="flex flex-wrap justify-center gap-2">
-              {cards.map((card, i) => (
-                <span
-                  key={i}
-                  className="px-3 py-1.5 rounded-lg border border-border bg-accent/50 text-sm font-medium"
-                >
-                  <TargetLanguageText language={targetLanguage}>
-                    {card.card_text}
-                  </TargetLanguageText>
-                  {showSubtitle && card.card_subtitle && (
-                    <span className="ml-1.5 text-xs text-muted-foreground">
-                      {card.card_subtitle}
-                    </span>
-                  )}
-                </span>
-              ))}
+        {CARD_GROUPS.map(({ type, label, showSubtitle }) => {
+          const cards = byType.get(type);
+          if (!cards || cards.length === 0) return null;
+          return (
+            <div key={type} className="space-y-2">
+              <p className="text-sm font-medium text-muted-foreground text-center">
+                {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
+              </p>
+              <div className="flex flex-wrap justify-center gap-2">
+                {cards.map((card, i) => (
+                  <span
+                    key={i}
+                    className="px-3 py-1.5 rounded-lg border border-border bg-accent/50 text-sm font-medium"
+                  >
+                    <TargetLanguageText language={targetLanguage}>
+                      {card.card_text}
+                    </TargetLanguageText>
+                    {showSubtitle && card.card_subtitle && (
+                      <span className="ml-1.5 text-xs text-muted-foreground">
+                        {card.card_subtitle}
+                      </span>
+                    )}
+                  </span>
+                ))}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+
+        <Button
+          onClick={() => onAccept(lockEvent)}
+          size="lg"
+          className="w-full"
+        >
+          Let's go
+        </Button>
+      </Card>
 
       <WeekProgressStrip deck={deck} />
-
-      <Button onClick={() => onAccept(lockEvent)} size="lg" className="w-full">
-        Let's go
-      </Button>
-    </Card>
+    </div>
   );
 }

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -8,14 +8,7 @@ import type {
   LockupOffer,
 } from "../../../yap-frontend-rs/pkg";
 import { TargetLanguageText } from "./TargetLanguageText";
-import { WeekProgressStrip } from "./no-cards-ready";
-
-interface LockupOfferScreenProps {
-  offer: LockupOffer;
-  deck: Deck;
-  targetLanguage: Language;
-  onAccept: (event: DeckEvent) => void;
-}
+import { WeekProgressStrip } from "./WeekProgressStrip";
 
 const CARD_GROUPS = [
   { type: "WrittenGram", label: "reading" },
@@ -23,20 +16,28 @@ const CARD_GROUPS = [
   { type: "LetterPronunciation", label: "pronunciation" },
 ] as const;
 
-/// Session-start screen shown when a review backlog builds up: keeps the most
-/// due cards active and sets the rest aside ("lockup").
-export function LockupOfferScreen({
-  offer,
+interface ReviewPlanCardProps {
+  title: string;
+  cards: CardSummary[];
+  buttonLabel: string;
+  onCommit: () => void;
+  deck: Deck;
+  targetLanguage: Language;
+}
+
+/// Shared layout for committing to a set of reviews: the lockup offer
+/// ("Today's review plan") and releasing more cards from lockup. Shows the
+/// cards grouped by type above a single commit button.
+export function ReviewPlanCard({
+  title,
+  cards,
+  buttonLabel,
+  onCommit,
   deck,
   targetLanguage,
-  onAccept,
-}: LockupOfferScreenProps) {
-  // wasm getters clone on every access, so read them once
-  const preview = offer.keep_preview;
-  const lockEvent = offer.lock_event;
-
+}: ReviewPlanCardProps) {
   const byType = new Map<string, CardSummary[]>();
-  for (const card of preview) {
+  for (const card of cards) {
     const type = card.card_indicator.type;
     byType.set(type, [...(byType.get(type) ?? []), card]);
   }
@@ -44,20 +45,18 @@ export function LockupOfferScreen({
   return (
     <div className="space-y-4">
       <Card className="max-w w-full p-6 gap-6 select-none" animate>
-        <h2 className="text-xl font-semibold text-center">
-          Today's review plan:
-        </h2>
+        <h2 className="text-xl font-semibold text-center">{title}</h2>
 
         {CARD_GROUPS.map(({ type, label }) => {
-          const cards = byType.get(type);
-          if (!cards || cards.length === 0) return null;
+          const group = byType.get(type);
+          if (!group || group.length === 0) return null;
           return (
             <div key={type} className="space-y-2">
               <p className="text-sm font-medium text-muted-foreground text-center">
-                {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
+                {group.length} {label} {group.length === 1 ? "card" : "cards"}
               </p>
               <div className="flex flex-wrap justify-center gap-y-1">
-                {cards.map((card, i) => (
+                {group.map((card, i) => (
                   <span
                     key={i}
                     className={`px-3 text-sm font-medium ${i > 0 ? "border-l border-border" : ""}`}
@@ -72,16 +71,43 @@ export function LockupOfferScreen({
           );
         })}
 
-        <Button
-          onClick={() => onAccept(lockEvent)}
-          size="lg"
-          className="w-full"
-        >
-          Let's go!
+        <Button onClick={onCommit} size="lg" className="w-full">
+          {buttonLabel}
         </Button>
       </Card>
 
       <WeekProgressStrip deck={deck} />
     </div>
+  );
+}
+
+interface LockupOfferScreenProps {
+  offer: LockupOffer;
+  deck: Deck;
+  targetLanguage: Language;
+  onAccept: (event: DeckEvent) => void;
+}
+
+/// Session-start screen shown when a review backlog builds up: keeps the most
+/// due cards active and sets the rest aside ("lockup").
+export function LockupOfferScreen({
+  offer,
+  deck,
+  targetLanguage,
+  onAccept,
+}: LockupOfferScreenProps) {
+  // wasm getters clone on every access, so read them once
+  const preview = offer.keep_preview;
+  const lockEvent = offer.lock_event;
+
+  return (
+    <ReviewPlanCard
+      title="Today's review plan:"
+      cards={preview}
+      buttonLabel="Let's go!"
+      onCommit={() => onAccept(lockEvent)}
+      deck={deck}
+      targetLanguage={targetLanguage}
+    />
   );
 }

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -76,7 +76,7 @@ export function ReviewPlanCard({
         </Button>
       </Card>
 
-      <WeekProgressStrip deck={deck} className="mt-auto" />
+      <WeekProgressStrip deck={deck} className="mt-auto mb-2" />
     </div>
   );
 }

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -45,7 +45,7 @@ export function LockupOfferScreen({
     <div className="space-y-4">
       <Card className="max-w w-full p-6 gap-6 select-none" animate>
         <h2 className="text-xl font-semibold text-center">
-          Let's review these cards today
+          Today's review plan:
         </h2>
 
         {CARD_GROUPS.map(({ type, label }) => {
@@ -77,7 +77,7 @@ export function LockupOfferScreen({
           size="lg"
           className="w-full"
         >
-          Let's go
+          Let's go!
         </Button>
       </Card>
 

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -53,9 +53,13 @@ export function LockupOfferScreen({
           if (!cards || cards.length === 0) return null;
           return (
             <div key={type} className="space-y-2">
-              <p className="text-sm font-medium text-muted-foreground text-center">
-                {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
-              </p>
+              <div className="flex items-center gap-3">
+                <div className="flex-1 border-t border-border" />
+                <p className="text-sm font-medium text-muted-foreground">
+                  {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
+                </p>
+                <div className="flex-1 border-t border-border" />
+              </div>
               <div className="flex flex-wrap justify-center gap-y-1">
                 {cards.map((card, i) => (
                   <span

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import type {
+  DeckEvent,
+  Language,
+  LockupOffer,
+} from "../../../yap-frontend-rs/pkg";
+import { TargetLanguageText } from "./TargetLanguageText";
+
+interface LockupOfferScreenProps {
+  offer: LockupOffer;
+  targetLanguage: Language;
+  onAccept: (event: DeckEvent) => void;
+}
+
+/// Session-start screen shown when a review backlog builds up: keeps the most
+/// due cards active and sets the rest aside ("lockup").
+export function LockupOfferScreen({
+  offer,
+  targetLanguage,
+  onAccept,
+}: LockupOfferScreenProps) {
+  // wasm getters clone on every access, so read them once
+  const preview = offer.keep_preview;
+  const lockEvent = offer.lock_event;
+
+  return (
+    <Card className="max-w w-full p-6 gap-4 select-none" animate>
+      <h2 className="text-xl font-semibold text-center">
+        Let's review these {preview.length} cards today
+      </h2>
+
+      <div className="flex flex-wrap justify-center gap-2">
+        {preview.map((card, i) => (
+          <span
+            key={i}
+            className="px-3 py-1.5 rounded-lg border border-border bg-accent/50 text-sm font-medium"
+          >
+            <TargetLanguageText language={targetLanguage}>
+              {card.card_text}
+            </TargetLanguageText>
+            {card.card_subtitle && (
+              <span className="ml-1.5 text-xs text-muted-foreground">
+                {card.card_subtitle}
+              </span>
+            )}
+          </span>
+        ))}
+      </div>
+
+      <p className="text-muted-foreground text-center">
+        The rest are set aside for later.
+      </p>
+
+      <Button onClick={() => onAccept(lockEvent)} size="lg" className="w-full">
+        Let's go
+      </Button>
+    </Card>
+  );
+}

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import type {
+  CardSummary,
   DeckEvent,
   Language,
   LockupOffer,
@@ -13,6 +14,12 @@ interface LockupOfferScreenProps {
   onAccept: (event: DeckEvent) => void;
 }
 
+const CARD_GROUPS = [
+  { type: "WrittenGram", label: "reading", showSubtitle: true },
+  { type: "ListeningGram", label: "listening", showSubtitle: false },
+  { type: "LetterPronunciation", label: "pronunciation", showSubtitle: false },
+] as const;
+
 /// Session-start screen shown when a review backlog builds up: keeps the most
 /// due cards active and sets the rest aside ("lockup").
 export function LockupOfferScreen({
@@ -24,29 +31,46 @@ export function LockupOfferScreen({
   const preview = offer.keep_preview;
   const lockEvent = offer.lock_event;
 
+  const byType = new Map<string, CardSummary[]>();
+  for (const card of preview) {
+    const type = card.card_indicator.type;
+    byType.set(type, [...(byType.get(type) ?? []), card]);
+  }
+
   return (
     <Card className="max-w w-full p-6 gap-4 select-none" animate>
       <h2 className="text-xl font-semibold text-center">
-        Let's review these {preview.length} cards today
+        Let's review these cards today
       </h2>
 
-      <div className="flex flex-wrap justify-center gap-2">
-        {preview.map((card, i) => (
-          <span
-            key={i}
-            className="px-3 py-1.5 rounded-lg border border-border bg-accent/50 text-sm font-medium"
-          >
-            <TargetLanguageText language={targetLanguage}>
-              {card.card_text}
-            </TargetLanguageText>
-            {card.card_subtitle && (
-              <span className="ml-1.5 text-xs text-muted-foreground">
-                {card.card_subtitle}
-              </span>
-            )}
-          </span>
-        ))}
-      </div>
+      {CARD_GROUPS.map(({ type, label, showSubtitle }) => {
+        const cards = byType.get(type);
+        if (!cards || cards.length === 0) return null;
+        return (
+          <div key={type} className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground text-center">
+              {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
+            </p>
+            <div className="flex flex-wrap justify-center gap-2">
+              {cards.map((card, i) => (
+                <span
+                  key={i}
+                  className="px-3 py-1.5 rounded-lg border border-border bg-accent/50 text-sm font-medium"
+                >
+                  <TargetLanguageText language={targetLanguage}>
+                    {card.card_text}
+                  </TargetLanguageText>
+                  {showSubtitle && card.card_subtitle && (
+                    <span className="ml-1.5 text-xs text-muted-foreground">
+                      {card.card_subtitle}
+                    </span>
+                  )}
+                </span>
+              ))}
+            </div>
+          </div>
+        );
+      })}
 
       <p className="text-muted-foreground text-center">
         The rest are set aside for later.

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -48,29 +48,31 @@ export function LockupOfferScreen({
           Let's review these cards today
         </h2>
 
-        {CARD_GROUPS.map(({ type, label }) => {
-          const cards = byType.get(type);
-          if (!cards || cards.length === 0) return null;
-          return (
-            <div key={type} className="space-y-2">
-              <p className="text-sm font-medium text-muted-foreground text-center">
-                {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
-              </p>
-              <div className="flex flex-wrap justify-center gap-y-1">
-                {cards.map((card, i) => (
-                  <span
-                    key={i}
-                    className={`px-3 text-sm font-medium ${i > 0 ? "border-l border-border" : ""}`}
-                  >
-                    <TargetLanguageText language={targetLanguage}>
-                      {card.card_text}
-                    </TargetLanguageText>
-                  </span>
-                ))}
+        <div className="space-y-6">
+          {CARD_GROUPS.map(({ type, label }) => {
+            const cards = byType.get(type);
+            if (!cards || cards.length === 0) return null;
+            return (
+              <div key={type} className="space-y-2">
+                <p className="text-sm font-medium text-muted-foreground text-center">
+                  {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
+                </p>
+                <div className="flex flex-wrap justify-center gap-y-1">
+                  {cards.map((card, i) => (
+                    <span
+                      key={i}
+                      className={`px-3 text-sm font-medium ${i > 0 ? "border-l border-border" : ""}`}
+                    >
+                      <TargetLanguageText language={targetLanguage}>
+                        {card.card_text}
+                      </TargetLanguageText>
+                    </span>
+                  ))}
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
 
         <Button
           onClick={() => onAccept(lockEvent)}

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -43,36 +43,34 @@ export function LockupOfferScreen({
 
   return (
     <div className="space-y-4">
-      <Card className="max-w w-full p-6 gap-4 select-none" animate>
+      <Card className="max-w w-full p-6 gap-6 select-none" animate>
         <h2 className="text-xl font-semibold text-center">
           Let's review these cards today
         </h2>
 
-        <div className="space-y-6">
-          {CARD_GROUPS.map(({ type, label }) => {
-            const cards = byType.get(type);
-            if (!cards || cards.length === 0) return null;
-            return (
-              <div key={type} className="space-y-2">
-                <p className="text-sm font-medium text-muted-foreground text-center">
-                  {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
-                </p>
-                <div className="flex flex-wrap justify-center gap-y-1">
-                  {cards.map((card, i) => (
-                    <span
-                      key={i}
-                      className={`px-3 text-sm font-medium ${i > 0 ? "border-l border-border" : ""}`}
-                    >
-                      <TargetLanguageText language={targetLanguage}>
-                        {card.card_text}
-                      </TargetLanguageText>
-                    </span>
-                  ))}
-                </div>
+        {CARD_GROUPS.map(({ type, label }) => {
+          const cards = byType.get(type);
+          if (!cards || cards.length === 0) return null;
+          return (
+            <div key={type} className="space-y-2">
+              <p className="text-sm font-medium text-muted-foreground text-center">
+                {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
+              </p>
+              <div className="flex flex-wrap justify-center gap-y-1">
+                {cards.map((card, i) => (
+                  <span
+                    key={i}
+                    className={`px-3 text-sm font-medium ${i > 0 ? "border-l border-border" : ""}`}
+                  >
+                    <TargetLanguageText language={targetLanguage}>
+                      {card.card_text}
+                    </TargetLanguageText>
+                  </span>
+                ))}
               </div>
-            );
-          })}
-        </div>
+            </div>
+          );
+        })}
 
         <Button
           onClick={() => onAccept(lockEvent)}

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -53,13 +53,9 @@ export function LockupOfferScreen({
           if (!cards || cards.length === 0) return null;
           return (
             <div key={type} className="space-y-2">
-              <div className="flex items-center gap-3">
-                <div className="flex-1 border-t border-border" />
-                <p className="text-sm font-medium text-muted-foreground">
-                  {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
-                </p>
-                <div className="flex-1 border-t border-border" />
-              </div>
+              <p className="text-sm font-medium text-muted-foreground text-center">
+                {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
+              </p>
               <div className="flex flex-wrap justify-center gap-y-1">
                 {cards.map((card, i) => (
                   <span

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -18,9 +18,9 @@ interface LockupOfferScreenProps {
 }
 
 const CARD_GROUPS = [
-  { type: "WrittenGram", label: "reading", showSubtitle: true },
-  { type: "ListeningGram", label: "listening", showSubtitle: false },
-  { type: "LetterPronunciation", label: "pronunciation", showSubtitle: false },
+  { type: "WrittenGram", label: "reading" },
+  { type: "ListeningGram", label: "listening" },
+  { type: "LetterPronunciation", label: "pronunciation" },
 ] as const;
 
 /// Session-start screen shown when a review backlog builds up: keeps the most
@@ -48,7 +48,7 @@ export function LockupOfferScreen({
           Let's review these cards today
         </h2>
 
-        {CARD_GROUPS.map(({ type, label, showSubtitle }) => {
+        {CARD_GROUPS.map(({ type, label }) => {
           const cards = byType.get(type);
           if (!cards || cards.length === 0) return null;
           return (
@@ -56,20 +56,15 @@ export function LockupOfferScreen({
               <p className="text-sm font-medium text-muted-foreground text-center">
                 {cards.length} {label} {cards.length === 1 ? "card" : "cards"}
               </p>
-              <div className="flex flex-wrap justify-center gap-2">
+              <div className="flex flex-wrap justify-center gap-y-1">
                 {cards.map((card, i) => (
                   <span
                     key={i}
-                    className="px-3 py-1.5 rounded-lg border border-border bg-accent/50 text-sm font-medium"
+                    className={`px-3 text-sm font-medium ${i > 0 ? "border-l border-border" : ""}`}
                   >
                     <TargetLanguageText language={targetLanguage}>
                       {card.card_text}
                     </TargetLanguageText>
-                    {showSubtitle && card.card_subtitle && (
-                      <span className="ml-1.5 text-xs text-muted-foreground">
-                        {card.card_subtitle}
-                      </span>
-                    )}
                   </span>
                 ))}
               </div>

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -2,14 +2,17 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import type {
   CardSummary,
+  Deck,
   DeckEvent,
   Language,
   LockupOffer,
 } from "../../../yap-frontend-rs/pkg";
 import { TargetLanguageText } from "./TargetLanguageText";
+import { WeekProgressStrip } from "./no-cards-ready";
 
 interface LockupOfferScreenProps {
   offer: LockupOffer;
+  deck: Deck;
   targetLanguage: Language;
   onAccept: (event: DeckEvent) => void;
 }
@@ -24,6 +27,7 @@ const CARD_GROUPS = [
 /// due cards active and sets the rest aside ("lockup").
 export function LockupOfferScreen({
   offer,
+  deck,
   targetLanguage,
   onAccept,
 }: LockupOfferScreenProps) {
@@ -72,9 +76,7 @@ export function LockupOfferScreen({
         );
       })}
 
-      <p className="text-muted-foreground text-center">
-        The rest are set aside for later.
-      </p>
+      <WeekProgressStrip deck={deck} />
 
       <Button onClick={() => onAccept(lockEvent)} size="lg" className="w-full">
         Let's go

--- a/yap-frontend/src/components/LockupOffer.tsx
+++ b/yap-frontend/src/components/LockupOffer.tsx
@@ -43,7 +43,7 @@ export function ReviewPlanCard({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col flex-1 gap-4">
       <Card className="max-w w-full p-6 gap-6 select-none" animate>
         <h2 className="text-xl font-semibold text-center">{title}</h2>
 
@@ -76,7 +76,7 @@ export function ReviewPlanCard({
         </Button>
       </Card>
 
-      <WeekProgressStrip deck={deck} />
+      <WeekProgressStrip deck={deck} className="mt-auto" />
     </div>
   );
 }

--- a/yap-frontend/src/components/TopPageLayout.tsx
+++ b/yap-frontend/src/components/TopPageLayout.tsx
@@ -16,7 +16,6 @@ interface TopPageLayoutProps {
       onBack: () => void;
     };
     title?: string;
-    dueCount?: number;
     dailyGoalPercent?: number;
   };
 }

--- a/yap-frontend/src/components/WeekProgressStrip.tsx
+++ b/yap-frontend/src/components/WeekProgressStrip.tsx
@@ -21,11 +21,17 @@ function useMidnightTick() {
   return day;
 }
 
-export function WeekProgressStrip({ deck }: { deck: Deck }) {
+export function WeekProgressStrip({
+  deck,
+  className = "",
+}: {
+  deck: Deck;
+  className?: string;
+}) {
   const day = useMidnightTick();
   const week = useMemo(() => deck.get_current_week_progress(), [deck, day]); // eslint-disable-line react-hooks/exhaustive-deps
   return (
-    <div className="flex w-full items-stretch">
+    <div className={`flex w-full items-stretch ${className}`}>
       {week.map((day, i) => (
         <DayCell key={i} day={day} index={i} />
       ))}

--- a/yap-frontend/src/components/WeekProgressStrip.tsx
+++ b/yap-frontend/src/components/WeekProgressStrip.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from "react";
+import type { Deck } from "../../../yap-frontend-rs/pkg";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+} from "@/components/ui/tooltip";
+
+const DAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
+
+function useMidnightTick() {
+  const [day, setDay] = useState(() => new Date().toDateString());
+  useEffect(() => {
+    const now = new Date();
+    const midnight = new Date(now);
+    midnight.setHours(24, 0, 0, 0);
+    const ms = midnight.getTime() - now.getTime();
+    const timer = setTimeout(() => setDay(new Date().toDateString()), ms);
+    return () => clearTimeout(timer);
+  }, [day]);
+  return day;
+}
+
+export function WeekProgressStrip({ deck }: { deck: Deck }) {
+  const day = useMidnightTick();
+  const week = useMemo(() => deck.get_current_week_progress(), [deck, day]); // eslint-disable-line react-hooks/exhaustive-deps
+  return (
+    <div className="flex w-full items-stretch">
+      {week.map((day, i) => (
+        <DayCell key={i} day={day} index={i} />
+      ))}
+    </div>
+  );
+}
+
+function DayCell({ day, index }: { day: { seconds: number; target_seconds: number; reviews: number; new_cards: number; learned_cards: number; locked_in_cards: number; met_goal: boolean; is_today: boolean; is_future: boolean }; index: number }) {
+  const fillPercent = day.is_future || day.target_seconds === 0
+    ? 0
+    : Math.min(100, (day.seconds / day.target_seconds) * 100);
+
+  const borderL = "";
+  const rounded =
+    index === 0
+      ? "rounded-l-lg"
+      : index === 6
+        ? "rounded-r-lg"
+        : "";
+  const todayClasses = day.is_today
+    ? "scale-110 z-10 rounded-lg shadow-lg border border-border"
+    : "";
+
+  const content = (
+    <>
+      <span className="text-lg font-semibold leading-none tabular-nums">
+        {day.is_future ? "·" : `+${day.new_cards + day.learned_cards + day.locked_in_cards}`}
+      </span>
+      <span className="text-[10px] uppercase tracking-wide opacity-70">
+        {DAY_LABELS[index]}
+      </span>
+    </>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className={`flex-1 relative overflow-hidden ${borderL} ${rounded} ${todayClasses} ${day.is_future ? "bg-muted/30" : `backdrop-brightness-105 backdrop-saturate-120 dark:backdrop-brightness-100 backdrop-blur-sm ${day.seconds > 0 ? "bg-foreground/10" : ""}`}`}
+        >
+          {/* Green fill bar */}
+          {!day.is_future && fillPercent > 0 && (
+            <div
+              className={`absolute inset-0 ${fillPercent >= 100 ? "bg-foreground" : "bg-foreground/90"}`}
+              style={{ clipPath: `inset(${100 - fillPercent}% 0 0 0)` }}
+            />
+          )}
+
+          {/* Base text layer (normal foreground color) */}
+          <div className={`relative flex flex-col items-center justify-center py-3 gap-0.5 ${day.is_future ? "text-muted-foreground/60" : "text-foreground"}`}>
+            {content}
+          </div>
+
+          {/* Clipped text layer (white, revealed by fill) */}
+          {!day.is_future && fillPercent > 0 && (
+            <div
+              className="absolute inset-0 flex flex-col items-center justify-center py-3 gap-0.5 text-background"
+              style={{ clipPath: `inset(${100 - fillPercent}% 0 0 0)` }}
+            >
+              {content}
+            </div>
+          )}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        {day.is_future
+          ? "Upcoming"
+          : day.reviews === 0
+            ? "No activity"
+            : `${day.new_cards} added · ${day.learned_cards + day.locked_in_cards} back on track`}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/yap-frontend/src/components/header.tsx
+++ b/yap-frontend/src/components/header.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { ModeToggle } from "@/components/mode-toggle";
 import { Card } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,7 +29,6 @@ interface HeaderProps {
     onBack: () => void;
   };
   title?: string;
-  dueCount?: number;
   dailyGoalPercent?: number;
 }
 
@@ -59,7 +57,6 @@ export function Header({
   language,
   backButton,
   title = "Yap.Town",
-  dueCount,
   dailyGoalPercent,
 }: HeaderProps) {
   const [authOpen, setAuthOpen] = useState(false);
@@ -125,14 +122,6 @@ export function Header({
           )}
         </div>
         <div className="flex items-center gap-2">
-          {dueCount !== undefined && dueCount > 0 && (
-            <Badge
-              variant="outline"
-              className="text-xs text-muted-foreground border-muted-foreground"
-            >
-              {dueCount}
-            </Badge>
-          )}
           {userInfo ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -35,6 +35,8 @@ import type { UserInfo } from "@/App";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Poster } from "@/components/Poster";
 import { TargetLanguageText } from "./TargetLanguageText";
+import { ReviewPlanCard } from "./LockupOffer";
+import { WeekProgressStrip } from "./WeekProgressStrip";
 import { sentenceListToSelection, type SentenceList } from "@/hooks/useSentenceList";
 import { useNavigate } from "react-router-dom";
 
@@ -288,29 +290,19 @@ export const NoCardsReady = memo(function NoCardsReady({
   })();
 
   // While cards remain set aside in lockup, the whole add-cards area is
-  // replaced by releasing the next batch
+  // replaced by releasing the next batch — same layout as the lockup offer,
+  // since both are "commit to some reviews" moments
   if (releaseOffer) {
     const releaseCount = releaseOffer.release_count;
     return (
-      <div className="space-y-4">
-        <div className="text-center py-4">
-          <p className="text-2xl font-bold">All caught up!</p>
-        </div>
-        <div className="flex justify-center">
-          <Button
-            onClick={releaseLockedCards}
-            variant="default"
-            size="lg"
-            className="group relative overflow-hidden transition-all hover:scale-105 hover:shadow-lg"
-          >
-            <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent translate-x-[-200%] group-hover:translate-x-[200%] transition-transform duration-1000"></span>
-            <Sparkles className="h-5 w-5 mr-2 animate-pulse" />
-            Review {releaseCount} more {releaseCount === 1 ? "card" : "cards"}
-          </Button>
-        </div>
-        <WeekProgressStrip deck={deck} />
-        {showEngagementPrompts && <EngagementPrompts language={targetLanguage} />}
-      </div>
+      <ReviewPlanCard
+        title="All caught up!"
+        cards={releaseOffer.release_preview}
+        buttonLabel={`Review ${releaseCount} more ${releaseCount === 1 ? "card" : "cards"}`}
+        onCommit={releaseLockedCards}
+        deck={deck}
+        targetLanguage={targetLanguage}
+      />
     );
   }
 
@@ -661,97 +653,3 @@ export const NoCardsReady = memo(function NoCardsReady({
   );
 });
 
-const DAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
-
-function useMidnightTick() {
-  const [day, setDay] = useState(() => new Date().toDateString());
-  useEffect(() => {
-    const now = new Date();
-    const midnight = new Date(now);
-    midnight.setHours(24, 0, 0, 0);
-    const ms = midnight.getTime() - now.getTime();
-    const timer = setTimeout(() => setDay(new Date().toDateString()), ms);
-    return () => clearTimeout(timer);
-  }, [day]);
-  return day;
-}
-
-export function WeekProgressStrip({ deck }: { deck: Deck }) {
-  const day = useMidnightTick();
-  const week = useMemo(() => deck.get_current_week_progress(), [deck, day]); // eslint-disable-line react-hooks/exhaustive-deps
-  return (
-    <div className="flex w-full items-stretch">
-      {week.map((day, i) => (
-        <DayCell key={i} day={day} index={i} />
-      ))}
-    </div>
-  );
-}
-
-function DayCell({ day, index }: { day: { seconds: number; target_seconds: number; reviews: number; new_cards: number; learned_cards: number; locked_in_cards: number; met_goal: boolean; is_today: boolean; is_future: boolean }; index: number }) {
-  const fillPercent = day.is_future || day.target_seconds === 0
-    ? 0
-    : Math.min(100, (day.seconds / day.target_seconds) * 100);
-
-  const borderL = "";
-  const rounded =
-    index === 0
-      ? "rounded-l-lg"
-      : index === 6
-        ? "rounded-r-lg"
-        : "";
-  const todayClasses = day.is_today
-    ? "scale-110 z-10 rounded-lg shadow-lg border border-border"
-    : "";
-
-  const content = (
-    <>
-      <span className="text-lg font-semibold leading-none tabular-nums">
-        {day.is_future ? "·" : `+${day.new_cards + day.learned_cards + day.locked_in_cards}`}
-      </span>
-      <span className="text-[10px] uppercase tracking-wide opacity-70">
-        {DAY_LABELS[index]}
-      </span>
-    </>
-  );
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div
-          className={`flex-1 relative overflow-hidden ${borderL} ${rounded} ${todayClasses} ${day.is_future ? "bg-muted/30" : `backdrop-brightness-105 backdrop-saturate-120 dark:backdrop-brightness-100 backdrop-blur-sm ${day.seconds > 0 ? "bg-foreground/10" : ""}`}`}
-        >
-          {/* Green fill bar */}
-          {!day.is_future && fillPercent > 0 && (
-            <div
-              className={`absolute inset-0 ${fillPercent >= 100 ? "bg-foreground" : "bg-foreground/90"}`}
-              style={{ clipPath: `inset(${100 - fillPercent}% 0 0 0)` }}
-            />
-          )}
-
-          {/* Base text layer (normal foreground color) */}
-          <div className={`relative flex flex-col items-center justify-center py-3 gap-0.5 ${day.is_future ? "text-muted-foreground/60" : "text-foreground"}`}>
-            {content}
-          </div>
-
-          {/* Clipped text layer (white, revealed by fill) */}
-          {!day.is_future && fillPercent > 0 && (
-            <div
-              className="absolute inset-0 flex flex-col items-center justify-center py-3 gap-0.5 text-background"
-              style={{ clipPath: `inset(${100 - fillPercent}% 0 0 0)` }}
-            >
-              {content}
-            </div>
-          )}
-        </div>
-      </TooltipTrigger>
-      <TooltipContent>
-        {day.is_future
-          ? "Upcoming"
-          : day.reviews === 0
-            ? "No activity"
-            : `${day.new_cards} added · ${day.learned_cards + day.locked_in_cards} back on track`}
-      </TooltipContent>
-    </Tooltip>
-  );
-}

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -322,9 +322,12 @@ export const NoCardsReady = memo(function NoCardsReady({
     }
 
     return (
-      <div className="flex flex-col gap-4 pt-4">
+      <div className="flex flex-col flex-1 gap-4 pt-4">
         <div className="flex flex-col gap-2 text-center">
           <p className="text-2xl font-bold">Nice job!</p>
+          <p className="text-muted-foreground">
+            You can take a break, or review more.
+          </p>
           {nextDueSoon && (
             <NextReviewLine
               nextDueCard={nextDueCard}
@@ -341,13 +344,13 @@ export const NoCardsReady = memo(function NoCardsReady({
             Review more
           </Button>
         </div>
-        <WeekProgressStrip deck={deck} />
+        <WeekProgressStrip deck={deck} className="mt-auto" />
       </div>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <div className="flex flex-col flex-1 gap-4">
       <div className="text-center py-4">
         <div className="flex flex-col gap-2">
           <p className="text-2xl font-bold">
@@ -662,9 +665,11 @@ export const NoCardsReady = memo(function NoCardsReady({
         </Card>
       )}
 
-      {!noSchedulableCards && <WeekProgressStrip deck={deck} />}
-
       {showEngagementPrompts && <EngagementPrompts language={targetLanguage} />}
+
+      {!noSchedulableCards && (
+        <WeekProgressStrip deck={deck} className="mt-auto" />
+      )}
     </div>
   );
 });

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -101,6 +101,15 @@ export const NoCardsReady = memo(function NoCardsReady({
     }
   }, [info.smart_add_event, addEvent]);
 
+  // While any cards are set aside in lockup, adding new cards is suppressed
+  // and replaced by releasing the next batch from lockup
+  const releaseOffer = useMemo(() => deck.get_release_offer(), [deck]);
+  const releaseLockedCards = useCallback(() => {
+    if (releaseOffer) {
+      addEvent(releaseOffer.unlock_event);
+    }
+  }, [releaseOffer, addEvent]);
+
   let nextTargetLanguageWord: string | null = null;
   if (
     nextDueCard &&
@@ -148,12 +157,14 @@ export const NoCardsReady = memo(function NoCardsReady({
         return;
       }
 
-      if (
-        (event.code === "Space" || event.code === "Enter") &&
-        info.smart_add_event
-      ) {
-        event.preventDefault();
-        addSmartCards();
+      if (event.code === "Space" || event.code === "Enter") {
+        if (releaseOffer) {
+          event.preventDefault();
+          releaseLockedCards();
+        } else if (info.smart_add_event) {
+          event.preventDefault();
+          addSmartCards();
+        }
       }
     };
 
@@ -162,7 +173,7 @@ export const NoCardsReady = memo(function NoCardsReady({
     return () => {
       window.removeEventListener("keydown", handleKeyPress);
     };
-  }, [addSmartCards, info.smart_add_event]);
+  }, [addSmartCards, info.smart_add_event, releaseOffer, releaseLockedCards]);
 
   // Sentence list navigation — 3 tabs: essential, movie, pimsleur
   // Each tab auto-picks the best specific sentence list within that category
@@ -275,6 +286,33 @@ export const NoCardsReady = memo(function NoCardsReady({
         return null;
     }
   })();
+
+  // While cards remain set aside in lockup, the whole add-cards area is
+  // replaced by releasing the next batch
+  if (releaseOffer) {
+    const releaseCount = releaseOffer.release_count;
+    return (
+      <div className="space-y-4">
+        <div className="text-center py-4">
+          <p className="text-2xl font-bold">All caught up!</p>
+        </div>
+        <div className="flex justify-center">
+          <Button
+            onClick={releaseLockedCards}
+            variant="default"
+            size="lg"
+            className="group relative overflow-hidden transition-all hover:scale-105 hover:shadow-lg"
+          >
+            <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent translate-x-[-200%] group-hover:translate-x-[200%] transition-transform duration-1000"></span>
+            <Sparkles className="h-5 w-5 mr-2 animate-pulse" />
+            Review {releaseCount} more {releaseCount === 1 ? "card" : "cards"}
+          </Button>
+        </div>
+        <WeekProgressStrip deck={deck} />
+        {showEngagementPrompts && <EngagementPrompts language={targetLanguage} />}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -322,17 +322,15 @@ export const NoCardsReady = memo(function NoCardsReady({
     }
 
     return (
-      <div className="space-y-4">
-        <div className="text-center py-4">
-          <div className="flex flex-col gap-2">
-            <p className="text-2xl font-bold">Nice job!</p>
-            {nextDueSoon && (
-              <NextReviewLine
-                nextDueCard={nextDueCard}
-                targetLanguage={targetLanguage}
-              />
-            )}
-          </div>
+      <div className="flex flex-col gap-4 pt-4">
+        <div className="flex flex-col gap-2 text-center">
+          <p className="text-2xl font-bold">Nice job!</p>
+          {nextDueSoon && (
+            <NextReviewLine
+              nextDueCard={nextDueCard}
+              targetLanguage={targetLanguage}
+            />
+          )}
         </div>
         <div className="flex justify-center">
           <Button

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -111,6 +111,19 @@ export const NoCardsReady = memo(function NoCardsReady({
       addEvent(releaseOffer.unlock_event);
     }
   }, [releaseOffer, addEvent]);
+  // Two-phase release: after reviewing today, first show a "Nice job!" rest
+  // screen; the review plan only appears once the user asks for more
+  const [showReleasePlan, setShowReleasePlan] = useState(false);
+  const releasePlanShown =
+    releaseOffer !== undefined &&
+    (deck.get_today_time_spent() === 0 || showReleasePlan);
+  const nextDueSoon = useMemo(
+    () =>
+      nextDueCard !== null &&
+      // eslint-disable-next-line react-hooks/purity -- point-in-time check; parent re-renders every minute
+      nextDueCard.due_timestamp_ms - Date.now() < 30 * 60 * 1000,
+    [nextDueCard],
+  );
 
   let nextTargetLanguageWord: string | null = null;
   if (
@@ -162,7 +175,11 @@ export const NoCardsReady = memo(function NoCardsReady({
       if (event.code === "Space" || event.code === "Enter") {
         if (releaseOffer) {
           event.preventDefault();
-          releaseLockedCards();
+          if (releasePlanShown) {
+            releaseLockedCards();
+          } else {
+            setShowReleasePlan(true);
+          }
         } else if (info.smart_add_event) {
           event.preventDefault();
           addSmartCards();
@@ -175,7 +192,13 @@ export const NoCardsReady = memo(function NoCardsReady({
     return () => {
       window.removeEventListener("keydown", handleKeyPress);
     };
-  }, [addSmartCards, info.smart_add_event, releaseOffer, releaseLockedCards]);
+  }, [
+    addSmartCards,
+    info.smart_add_event,
+    releaseOffer,
+    releaseLockedCards,
+    releasePlanShown,
+  ]);
 
   // Sentence list navigation — 3 tabs: essential, movie, pimsleur
   // Each tab auto-picks the best specific sentence list within that category
@@ -290,19 +313,44 @@ export const NoCardsReady = memo(function NoCardsReady({
   })();
 
   // While cards remain set aside in lockup, the whole add-cards area is
-  // replaced by releasing the next batch — same layout as the lockup offer,
-  // since both are "commit to some reviews" moments
+  // replaced by releasing the next batch. Never says "all caught up" — that's
+  // only true once nothing is locked. Two phases: a rest screen after today's
+  // reviews, then the same review-plan page as the lockup offer.
   if (releaseOffer) {
-    const releaseCount = releaseOffer.release_count;
+    if (releasePlanShown) {
+      return (
+        <ReviewPlanCard
+          title="Today's review plan:"
+          cards={releaseOffer.release_preview}
+          buttonLabel="Let's go!"
+          onCommit={releaseLockedCards}
+          deck={deck}
+          targetLanguage={targetLanguage}
+        />
+      );
+    }
+
     return (
-      <ReviewPlanCard
-        title="All caught up!"
-        cards={releaseOffer.release_preview}
-        buttonLabel={`Review ${releaseCount} more ${releaseCount === 1 ? "card" : "cards"}`}
-        onCommit={releaseLockedCards}
-        deck={deck}
-        targetLanguage={targetLanguage}
-      />
+      <div className="space-y-4">
+        <Card className="max-w w-full p-6 gap-6 select-none" animate>
+          <h2 className="text-xl font-semibold text-center">Nice job!</h2>
+          {nextDueSoon && nextDueCard !== null && (
+            <p className="text-muted-foreground text-center">
+              Your next review is{" "}
+              <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />.
+            </p>
+          )}
+          <Button
+            onClick={() => setShowReleasePlan(true)}
+            size="lg"
+            variant="outline"
+            className="w-full"
+          >
+            Review more
+          </Button>
+        </Card>
+        <WeekProgressStrip deck={deck} />
+      </div>
     );
   }
 

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -308,6 +308,7 @@ export const NoCardsReady = memo(function NoCardsReady({
   // only true once nothing is locked. Two phases: a rest screen after today's
   // reviews, then the same review-plan page as the lockup offer.
   if (releaseOffer) {
+    const minutesToday = Math.round(deck.get_today_time_spent() / 60);
     if (releasePlanShown) {
       return (
         <ReviewPlanCard
@@ -326,7 +327,11 @@ export const NoCardsReady = memo(function NoCardsReady({
         <div className="flex flex-col gap-2 text-center">
           <p className="text-2xl font-bold">Nice job!</p>
           <p className="text-muted-foreground">
-            You can take a break, or review more.
+            You reviewed for{" "}
+            {minutesToday < 1
+              ? "less than a minute"
+              : `${minutesToday} ${minutesToday === 1 ? "minute" : "minutes"}`}{" "}
+            today. You can take a break, or review more.
           </p>
           {nextDueSoon && (
             <NextReviewLine

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -125,15 +125,6 @@ export const NoCardsReady = memo(function NoCardsReady({
     [nextDueCard],
   );
 
-  let nextTargetLanguageWord: string | null = null;
-  if (
-    nextDueCard &&
-    (nextDueCard.card_indicator.type === "WrittenPhrase" ||
-      nextDueCard.card_indicator.type === "WrittenGram")
-  ) {
-    nextTargetLanguageWord = nextDueCard?.card_text;
-  }
-
   // Calculate if workload looks light
   const showLightWorkloadNotification =
     info.cards_added_past_16_hours < 20 &&
@@ -332,23 +323,26 @@ export const NoCardsReady = memo(function NoCardsReady({
 
     return (
       <div className="space-y-4">
-        <Card className="max-w w-full p-6 gap-6 select-none" animate>
-          <h2 className="text-xl font-semibold text-center">Nice job!</h2>
-          {nextDueSoon && nextDueCard !== null && (
-            <p className="text-muted-foreground text-center">
-              Your next review is{" "}
-              <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />.
-            </p>
-          )}
+        <div className="text-center py-4">
+          <div className="flex flex-col gap-2">
+            <p className="text-2xl font-bold">Nice job!</p>
+            {nextDueSoon && (
+              <NextReviewLine
+                nextDueCard={nextDueCard}
+                targetLanguage={targetLanguage}
+              />
+            )}
+          </div>
+        </div>
+        <div className="flex justify-center">
           <Button
             onClick={() => setShowReleasePlan(true)}
             size="lg"
             variant="outline"
-            className="w-full"
           >
             Review more
           </Button>
-        </Card>
+        </div>
         <WeekProgressStrip deck={deck} />
       </div>
     );
@@ -384,34 +378,10 @@ export const NoCardsReady = memo(function NoCardsReady({
                 : "Add some cards to keep building your vocabulary."}
             </p>
           ) : (
-            <p className="text-muted-foreground">
-              {nextTargetLanguageWord ? (
-                <>
-                  You'll review{" "}
-                  <span className="font-semibold">
-                    <TargetLanguageText language={targetLanguage}>
-                      {nextTargetLanguageWord}
-                    </TargetLanguageText>
-                  </span>{" "}
-                  {nextDueCard ? (
-                    <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />
-                  ) : (
-                    "soon"
-                  )}
-                  .
-                </>
-              ) : (
-                <>
-                  Your next review is{" "}
-                  {nextDueCard ? (
-                    <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />
-                  ) : (
-                    "soon"
-                  )}
-                  .
-                </>
-              )}
-            </p>
+            <NextReviewLine
+              nextDueCard={nextDueCard}
+              targetLanguage={targetLanguage}
+            />
           )}
         </div>
       </div>
@@ -700,4 +670,53 @@ export const NoCardsReady = memo(function NoCardsReady({
     </div>
   );
 });
+
+/// "You'll review <word> in 2 minutes." / "Your next review is soon."
+function NextReviewLine({
+  nextDueCard,
+  targetLanguage,
+}: {
+  nextDueCard: CardSummary | null;
+  targetLanguage: Language;
+}) {
+  let nextTargetLanguageWord: string | null = null;
+  if (
+    nextDueCard &&
+    (nextDueCard.card_indicator.type === "WrittenPhrase" ||
+      nextDueCard.card_indicator.type === "WrittenGram")
+  ) {
+    nextTargetLanguageWord = nextDueCard.card_text;
+  }
+
+  return (
+    <p className="text-muted-foreground">
+      {nextTargetLanguageWord ? (
+        <>
+          You'll review{" "}
+          <span className="font-semibold">
+            <TargetLanguageText language={targetLanguage}>
+              {nextTargetLanguageWord}
+            </TargetLanguageText>
+          </span>{" "}
+          {nextDueCard ? (
+            <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />
+          ) : (
+            "soon"
+          )}
+          .
+        </>
+      ) : (
+        <>
+          Your next review is{" "}
+          {nextDueCard ? (
+            <TimeAgo date={new Date(nextDueCard.due_timestamp_ms)} />
+          ) : (
+            "soon"
+          )}
+          .
+        </>
+      )}
+    </p>
+  );
+}
 

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -676,7 +676,7 @@ function useMidnightTick() {
   return day;
 }
 
-function WeekProgressStrip({ deck }: { deck: Deck }) {
+export function WeekProgressStrip({ deck }: { deck: Deck }) {
   const day = useMidnightTick();
   const week = useMemo(() => deck.get_current_week_progress(), [deck, day]); // eslint-disable-line react-hooks/exhaustive-deps
   return (

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -325,13 +325,15 @@ export const NoCardsReady = memo(function NoCardsReady({
     return (
       <div className="flex flex-col flex-1 gap-4 pt-4">
         <div className="flex flex-col gap-2 text-center">
-          <p className="text-2xl font-bold">Nice job!</p>
-          <p className="text-muted-foreground">
-            You reviewed for{" "}
+          <p className="text-2xl font-bold">
+            Nice! You reviewed for{" "}
             {minutesToday < 1
               ? "less than a minute"
               : `${minutesToday} ${minutesToday === 1 ? "minute" : "minutes"}`}{" "}
-            today. You can take a break, or review more.
+            today!
+          </p>
+          <p className="text-muted-foreground">
+            You can take a break, or review more.
           </p>
           {nextDueSoon && (
             <NextReviewLine

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -351,7 +351,7 @@ export const NoCardsReady = memo(function NoCardsReady({
             Review more
           </Button>
         </div>
-        <WeekProgressStrip deck={deck} className="mt-auto" />
+        <WeekProgressStrip deck={deck} className="mt-auto mb-2" />
       </div>
     );
   }
@@ -675,7 +675,7 @@ export const NoCardsReady = memo(function NoCardsReady({
       {showEngagementPrompts && <EngagementPrompts language={targetLanguage} />}
 
       {!noSchedulableCards && (
-        <WeekProgressStrip deck={deck} className="mt-auto" />
+        <WeekProgressStrip deck={deck} className="mt-auto mb-2" />
       )}
     </div>
   );


### PR DESCRIPTION
## What

When a review backlog builds up (>20 due), a mandatory session-start screen keeps the **15 most-due** cards active and sets the rest aside ("lockup"). This breaks the backlog vicious cycle: slogging through 100+ reviews means the ~20% you failed come back far too late and are forgotten again. Failed cards from the active 15 still reschedule minutes out as usual, so the tight re-review loop is preserved.

- **Offer screen** (`LockupOffer.tsx`): "Let's review these 15 cards today" + chip cloud of the kept cards + "The rest are set aside for later." + "Let's go". Shown at most once per local day; no skip.
- **Release**: once caught up, the add-new-cards area becomes "Review 15 more cards", releasing the most-due locked cards. Adding new cards stays suppressed while anything is locked.
- The 20→15 gap is a deliberate wiggle zone so borderline days don't trigger the offer.

## Data model (V3-additive, no V4)

```rust
LockDueCardsExcept { keep: Vec<CardIndicator<...>> },
UnlockCards { cards: Vec<CardIndicator<...>> },
```

- `LockDueCardsExcept` stores the kept cards **explicitly** (exactly what the user saw/approved — deterministic under cross-device event interleaving) and locks the due-complement at replay.
- `Deck.locked_cards` is pure derived state; `get_review_info` gains a `due_but_locked_cards` bucket, so challenge selection, counts, and the header badge all exclude locked cards for free.
- Reviewing a locked card (e.g. from another device) auto-releases it.
- Lock/unlock events don't count as review activity (no streak/accomplishment side effects).
- Simulation treats locked cards as reviewable so year-long projections aren't skewed.
- Same forward-compat trade as when `SetDailyReviewTarget` shipped: stale open tabs can't parse the new variants until reload.

## Testing

- New replay tests: lock complement + release restore, offer thresholds (none at exactly 20, keeps 15 at 21, once per local day), review-auto-unlock, simulation includes locked.
- `cargo test` (all green), `cargo clippy` clean, `wasm-pack build --features local-backend` OK, `tsc -b` clean, `pnpm lint` at main baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoXbLCmLU4yUKQ8NHXD7ko