### PR TITLE
Lockup covers all cards; any review unlocks

### DIFF
--- a/yap-frontend-rs/src/deck_event/current.rs
+++ b/yap-frontend-rs/src/deck_event/current.rs
@@ -231,10 +231,11 @@ pub enum LanguageEventContent {
     SetDailyReviewTarget {
         daily_review_target: DailyReviewTarget,
     },
-    /// Lock up every card that is due at this event's timestamp, EXCEPT the
-    /// listed cards. Locked cards are hidden from the review queue until
-    /// released via `UnlockCards`.
-    LockDueCardsExcept {
+    /// Lock up every added card EXCEPT the listed ones. Locked cards are
+    /// hidden from the review queue (and only from the review queue) until
+    /// released via `UnlockCards` or until any review touches them.
+    #[serde(alias = "LockDueCardsExcept")]
+    LockCardsExcept {
         keep: Vec<CardIndicator<Gram<String>, String>>,
     },
     /// Release the listed cards from lockup.

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -1018,7 +1018,7 @@ pub struct DeckState {
     daily_review_target: DailyReviewTarget,
     /// Cards set aside ("locked up") and hidden from the review queue
     locked_cards: FxHashSet<CardIndicator<SpurGram, Spur>>,
-    /// The user's local day of the most recent LockDueCardsExcept event
+    /// The user's local day of the most recent LockCardsExcept event
     last_lock_day: Option<chrono::NaiveDate>,
 }
 
@@ -1042,7 +1042,7 @@ pub struct Deck {
     daily_review_target: DailyReviewTarget,
     /// Cards set aside ("locked up") and hidden from the review queue
     locked_cards: FxHashSet<CardIndicator<SpurGram, Spur>>,
-    /// The user's local day of the most recent LockDueCardsExcept event
+    /// The user's local day of the most recent LockCardsExcept event
     last_lock_day: Option<chrono::NaiveDate>,
 }
 
@@ -1129,7 +1129,7 @@ impl weapon::AppState for Deck {
             event,
             LanguageEventContent::SetSentenceList { .. }
                 | LanguageEventContent::SetDailyReviewTarget { .. }
-                | LanguageEventContent::LockDueCardsExcept { .. }
+                | LanguageEventContent::LockCardsExcept { .. }
                 | LanguageEventContent::UnlockCards { .. }
         );
         if counts_as_review_activity {
@@ -1242,10 +1242,6 @@ impl weapon::AppState for Deck {
                             .entry(flashcard_type)
                             .or_insert(0) += 1;
                     }
-
-                    // A card being actively reviewed (e.g. from another device)
-                    // is self-evidently not set aside
-                    deck.locked_cards.remove(&reviewed);
 
                     deck.log_review(reviewed, *rating, *timestamp, context);
                 }
@@ -1715,7 +1711,7 @@ impl weapon::AppState for Deck {
             } => {
                 deck.daily_review_target = daily_review_target.clone();
             }
-            LanguageEventContent::LockDueCardsExcept { keep } => {
+            LanguageEventContent::LockCardsExcept { keep } => {
                 let keep: FxHashSet<_> = keep
                     .iter()
                     .filter_map(|card| {
@@ -1725,9 +1721,14 @@ impl weapon::AppState for Deck {
                         )
                     })
                     .collect();
+                // Lock every schedulable added card outside the kept set —
+                // leeches and already-known cards never enter the review
+                // queue, so locking them would only make the release offer
+                // promise cards that can't appear
                 for (card, card_data) in deck.cards.iter() {
-                    if let CardData::Added { fsrs_card } = card_data
-                        && fsrs_card.due <= *timestamp
+                    if matches!(card_data, CardData::Added { .. })
+                        && !card_data.is_already_known()
+                        && !deck.leeches.contains_key(card)
                         && !keep.contains(card)
                     {
                         deck.locked_cards.insert(*card);
@@ -1990,6 +1991,11 @@ impl DeckState {
         timestamp: DateTime<Utc>,
         context: &Context,
     ) {
+        // ANY review releases a card from lockup — including incidental ones
+        // through sentence challenges, so a word we just discovered the user
+        // doesn't know can be reviewed immediately
+        self.locked_cards.remove(&card);
+
         // Make sure the card is valid before logging a review
         if !context.is_card_valid(&card) {
             return;
@@ -2380,10 +2386,11 @@ impl Deck {
 
     /// Returns all cards as summaries, ordered consistently with get_review_info
     /// (due cards first, then future cards, each sorted by due date and card indicator).
+    /// Includes locked cards — lockup only hides cards from the review queue.
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn get_all_cards_summary(&self) -> Vec<CardSummary> {
         let now = Utc::now().timestamp_millis() as f64;
-        let review_info = self.get_review_info(vec![], now);
+        let review_info = self.get_review_info_including_locked(now);
         review_info
             .due_cards
             .iter()
@@ -2528,7 +2535,7 @@ impl Deck {
         let lock_event = DeckEvent::Language(LanguageEvent {
             target_language: self.context.course.target_language,
             native_language: self.context.course.native_language,
-            content: LanguageEventContent::LockDueCardsExcept {
+            content: LanguageEventContent::LockCardsExcept {
                 keep: keep
                     .iter()
                     .map(|card| {
@@ -2547,14 +2554,29 @@ impl Deck {
     }
 
     /// The "Review N more cards" offer: releases the most-due locked cards.
-    /// None when nothing is locked.
+    /// None when no locked card is actually due — locked cards scheduled for
+    /// the future are morally just future cards, so they don't keep the user
+    /// in "release mode" (or block adding new cards).
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn get_release_offer(&self) -> Option<ReleaseOffer> {
-        if self.locked_cards.is_empty() {
+    pub fn get_release_offer(&self, timestamp_ms: f64) -> Option<ReleaseOffer> {
+        let now =
+            DateTime::<Utc>::from_timestamp_millis(timestamp_ms as i64).unwrap_or_else(Utc::now);
+        let mut locked: Vec<_> = self
+            .locked_cards
+            .iter()
+            .filter(|card| {
+                self.cards
+                    .get(card)
+                    .is_some_and(|card_data| match card_data {
+                        CardData::Added { fsrs_card } => fsrs_card.due <= now,
+                        CardData::Ghost { .. } => false,
+                    })
+            })
+            .copied()
+            .collect();
+        if locked.is_empty() {
             return None;
         }
-
-        let mut locked: Vec<_> = self.locked_cards.iter().copied().collect();
         locked.sort_by_key(|card_indicator| {
             let card_data = self.cards.get(card_indicator).unwrap();
             let due_timestamp = ordered_float::NotNan::new(card_data.due_timestamp_ms()).unwrap();
@@ -5252,12 +5274,12 @@ mod tests {
         assert_eq!(simulated.due_but_locked_count(), 0);
 
         // Release restores the most-due locked cards
-        let release = deck.get_release_offer().expect("release expected");
+        let release = deck.get_release_offer(t1_ms).expect("release expected");
         assert_eq!(release.release_count(), 10);
         let deck = apply_deck_event(deck, release.unlock_event(), t1);
         assert_eq!(deck.locked_count(), 0);
         assert_eq!(deck.get_review_info(vec![], t1_ms).due_count(), 25);
-        assert!(deck.get_release_offer().is_none());
+        assert!(deck.get_release_offer(t1_ms).is_none());
     }
 
     #[test]
@@ -5289,7 +5311,7 @@ mod tests {
             .expect("offer expected");
         let deck40 = apply_deck_event(deck40, offer.lock_event(), t1);
         assert_eq!(deck40.locked_count(), 25);
-        let release = deck40.get_release_offer().expect("release expected");
+        let release = deck40.get_release_offer(t1_ms).expect("release expected");
         assert_eq!(release.release_count(), 15);
         let deck40 = apply_deck_event(deck40, release.unlock_event(), t1);
         assert_eq!(deck40.get_review_info(vec![], t1_ms).due_count(), 30);
@@ -5329,6 +5351,141 @@ mod tests {
         let deck = apply_deck_event(deck, event, t1);
         assert_eq!(deck.locked_count(), 9);
         assert!(!deck.locked_cards.contains(&locked_card));
+    }
+
+    /// Review some cards Again-then-Easy so they lapse once (staying
+    /// schedulable — a never-failed card counts as already known and leaves
+    /// the queue entirely) and end up scheduled days into the future.
+    fn review_cards_to_future(
+        mut deck: Deck,
+        cards: &[CardIndicator<SpurGram, Spur>],
+        timestamp: DateTime<Utc>,
+    ) -> Deck {
+        for card in cards {
+            let resolved = card.resolve(
+                &deck.context.language_pack.string_rodeo,
+                &deck.context.language_pack.gram_rodeo,
+            );
+            for (rating, minutes) in [(Rating::Again, 0), (Rating::Easy, 5)] {
+                let event = deck.review_card(resolved.clone(), rating).unwrap();
+                deck =
+                    apply_deck_event(deck, event, timestamp + chrono::Duration::minutes(minutes));
+            }
+        }
+        deck
+    }
+
+    #[test]
+    fn test_lockup_covers_future_cards() {
+        use chrono::TimeZone;
+
+        let t0 = Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap();
+        let deck = deck_with_n_due_cards(30, t0);
+
+        // Review 5 cards Easy so they're scheduled days into the future
+        // (cards are staggered by milliseconds, so sample the queue after t0)
+        let t0_later_ms = (t0 + chrono::Duration::minutes(10)).timestamp_millis() as f64;
+        let reviewed: Vec<_> = deck.get_review_info(vec![], t0_later_ms).due_cards[..5].to_vec();
+        let deck = review_cards_to_future(deck, &reviewed, t0 + chrono::Duration::minutes(30));
+
+        // Lock up: 25 due, keep the 15 most-due — but EVERY added card outside
+        // the kept set is locked, including the 5 future ones
+        let t1 = t0 + chrono::Duration::hours(1);
+        let t1_ms = t1.timestamp_millis() as f64;
+        assert_eq!(deck.get_review_info(vec![], t1_ms).due_count(), 25);
+        let offer = deck
+            .get_lockup_offer(vec![], t1_ms)
+            .expect("offer expected");
+        let deck = apply_deck_event(deck, offer.lock_event(), t1);
+        assert_eq!(deck.locked_count(), 15);
+        for card in &reviewed {
+            assert!(deck.locked_cards.contains(card));
+        }
+
+        // Only the 10 currently-due locked cards are releasable today
+        let release = deck.get_release_offer(t1_ms).expect("release expected");
+        assert_eq!(release.release_count(), 10);
+
+        // Weeks later the future cards have come due — locked, not active
+        let t2 = t1 + chrono::Duration::days(30);
+        let t2_ms = t2.timestamp_millis() as f64;
+        let info = deck.get_review_info(vec![], t2_ms);
+        assert_eq!(info.due_count(), 15, "only the kept cards are active");
+        assert_eq!(info.due_but_locked_count(), 15);
+        for card in &reviewed {
+            assert!(info.due_but_locked_cards.contains(card));
+        }
+    }
+
+    #[test]
+    fn test_release_offer_none_when_no_locked_card_due() {
+        use chrono::TimeZone;
+
+        let t0 = Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap();
+        let deck = deck_with_n_due_cards(25, t0);
+
+        // (cards are staggered by milliseconds, so sample the queue after t0)
+        let t0_later_ms = (t0 + chrono::Duration::minutes(10)).timestamp_millis() as f64;
+        let reviewed: Vec<_> = deck.get_review_info(vec![], t0_later_ms).due_cards[..5].to_vec();
+        let deck = review_cards_to_future(deck, &reviewed, t0 + chrono::Duration::minutes(30));
+
+        // Hand-craft a lock event keeping every currently-due card, so the
+        // locked set consists solely of the 5 future-scheduled cards
+        let t1 = t0 + chrono::Duration::hours(1);
+        let t1_ms = t1.timestamp_millis() as f64;
+        let keep = deck
+            .get_review_info(vec![], t1_ms)
+            .due_cards
+            .iter()
+            .map(|card| {
+                card.resolve(
+                    &deck.context.language_pack.string_rodeo,
+                    &deck.context.language_pack.gram_rodeo,
+                )
+            })
+            .collect();
+        let lock_event = DeckEvent::Language(LanguageEvent {
+            target_language: deck.context.course.target_language,
+            native_language: deck.context.course.native_language,
+            content: LanguageEventContent::LockCardsExcept { keep },
+        });
+        let deck = apply_deck_event(deck, lock_event, t1);
+        assert_eq!(deck.locked_count(), 5);
+
+        // Locked cards exist but none are due: no release offer (the user is
+        // NOT in "release mode" — adding new cards stays available)
+        assert!(deck.get_release_offer(t1_ms).is_none());
+
+        // Once they come due, the release offer appears
+        let t2_ms = (t1 + chrono::Duration::days(30)).timestamp_millis() as f64;
+        let release = deck.get_release_offer(t2_ms).expect("release expected");
+        assert_eq!(release.release_count(), 5);
+    }
+
+    #[test]
+    fn test_incidental_review_unlocks_card() {
+        use chrono::TimeZone;
+        use weapon::AppState;
+
+        let t0 = Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap();
+        let t1 = t0 + chrono::Duration::hours(1);
+        let t1_ms = t1.timestamp_millis() as f64;
+        let deck = deck_with_n_due_cards(25, t0);
+
+        let offer = deck
+            .get_lockup_offer(vec![], t1_ms)
+            .expect("offer expected");
+        let deck = apply_deck_event(deck, offer.lock_event(), t1);
+        let locked_card = deck.get_review_info(vec![], t1_ms).due_but_locked_cards[0];
+
+        // ANY review path funnels through log_review (sentence translations,
+        // transcriptions, ...) and must release the card from lockup
+        let context = deck.context.clone();
+        let mut state = DeckState::from(deck);
+        state.log_review(locked_card, Rating::Again, t1, &context);
+        let deck = <Deck as AppState>::finalize(state, &context);
+        assert!(!deck.locked_cards.contains(&locked_card));
+        assert_eq!(deck.locked_count(), 9);
     }
 
     #[test]

--- a/yap-frontend-rs/src/notifications.rs
+++ b/yap-frontend-rs/src/notifications.rs
@@ -318,9 +318,10 @@ impl Deck {
     pub async fn submit_language_stats(&self, access_token: &str) -> Result<(), JsValue> {
         use language_utils::profile::UpdateLanguageStatsRequest;
 
-        // Get current stats from the deck
+        // Get current stats from the deck (locked cards still count — lockup
+        // only hides cards from the review queue)
         let now = js_sys::Date::now();
-        let review_info = self.get_review_info(vec![], now);
+        let review_info = self.get_review_info_including_locked(now);
 
         let total_count = review_info.total_count() as i64;
 

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -103,9 +103,16 @@ export const NoCardsReady = memo(function NoCardsReady({
     }
   }, [info.smart_add_event, addEvent]);
 
-  // While any cards are set aside in lockup, adding new cards is suppressed
-  // and replaced by releasing the next batch from lockup
-  const releaseOffer = useMemo(() => deck.get_release_offer(), [deck]);
+  // While any locked cards are DUE, adding new cards is suppressed and
+  // replaced by releasing the next batch from lockup. Locked cards scheduled
+  // for the future don't trigger this — they're morally just future cards.
+  // nextDueCard is a fresh object every parent render, so this re-evaluates
+  // as time passes (e.g. when a locked card comes due).
+  const releaseOffer = useMemo(
+    // eslint-disable-next-line react-hooks/purity -- point-in-time check; re-evaluated as the parent re-renders
+    () => deck.get_release_offer(Date.now()),
+    [deck, nextDueCard], // eslint-disable-line react-hooks/exhaustive-deps
+  );
   const releaseLockedCards = useCallback(() => {
     if (releaseOffer) {
       addEvent(releaseOffer.unlock_event);

--- a/yap-frontend/src/components/stats.tsx
+++ b/yap-frontend/src/components/stats.tsx
@@ -37,13 +37,14 @@ export const Stats = memo(function Stats({ deck: deckProp, targetLanguage }: Sta
     10000, // Update every 10 seconds
   );
 
-  const { reviewInfo, readyCards, allCardsSummary } = useMemo(() => {
-    const reviewInfo = deck.get_review_info([], currentTimestamp);
+  // Deliberately lockup-agnostic: locked cards are still cards in the deck,
+  // so they count as ready/not-ready like any other
+  const { readyCards, allCardsSummary } = useMemo(() => {
     const allCardsSummary = deck.get_all_cards_summary();
     const readyCards = allCardsSummary.filter(
       (card) => card.due_timestamp_ms <= currentTimestamp,
     );
-    return { reviewInfo, readyCards, allCardsSummary };
+    return { readyCards, allCardsSummary };
   }, [deck, currentTimestamp]);
   const notReadyCards = allCardsSummary.filter(
     (card) => card.due_timestamp_ms > currentTimestamp,
@@ -77,7 +78,7 @@ export const Stats = memo(function Stats({ deck: deckProp, targetLanguage }: Sta
       <NumericStats
         xp={deck.get_xp()}
         totalCards={allCardsSummary.length}
-        cardsReady={reviewInfo.due_count || 0}
+        cardsReady={readyCards.length}
         percentKnown={deck.get_percent_of_words_known() * 100}
         dailyStreak={deck.get_daily_streak()}
         totalReviews={deck.get_total_reviews()}


### PR DESCRIPTION
## Problem

Cards scheduled before a lockup came due into the **active** queue as time passed, so a big backlog rebuilt itself within days — defeating the feature (#115).

## Changes

**Lock everything except the kept cards.** `LockDueCardsExcept` → `LockCardsExcept` (with `#[serde(alias)]` so existing events keep parsing; their replay semantics widen from "due cards except keep" to "all schedulable added cards except keep" — which is the behavior those locks should have had). Future cards now come due *into* lockup instead of into the queue. Leeches and already-known cards are excluded from locking since they never enter the queue anyway.

**Release mode only while a locked card is due.** `get_release_offer(timestamp_ms)` returns the ≤15 most-due locked cards that are *currently due*, and `None` otherwise — locked future cards are morally just future cards, so they don't trap the user in release mode or block adding new cards. "All caught up" stays honest: nothing due, locked or not.

**Any review unlocks.** The unlock moved from the `ReviewCard` event arm into `log_review`, the funnel for every review path — flashcards, sentence-translation literals, transcriptions. If a sentence challenge incidentally reveals you don't know a locked word, it's immediately reviewable.

## Lockup only hides cards from the review queue — audit

- `get_all_cards_summary` now includes locked cards → stats page card list, notifications, `findNextDueCard` (which also schedules the re-render that surfaces the release flow when a locked card comes due)
- Stats page "ready" count now derives from the all-cards summary (was the filtered queue count)
- `submit_language_stats` total count includes locked cards
- Dictionary deck-membership reads `deck.cards` directly — unaffected
- Sentences/comprehensible grams are computed from `deck.cards` in `finalize` — locked cards still appear in sentences
- Simulation and audio pre-caching already used the include-locked path

## Testing

Six lockup replay tests (three new): future cards land in lockup and surface as due-but-locked weeks later; release offer is `None` when locked cards exist but none are due; incidental reviews through `log_review` unlock. Full `cargo test`, clippy, wasm build, `tsc -b`, lint at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoXbLCmLU4yUKQ8NHXD7ko