### PR TITLE
Fix Sentry noise and a missing catch in a few production error paths

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -249,7 +249,9 @@ function AppCheckLoggedIn({ weaponToken }: { weaponToken: WeaponToken }) {
       }
     };
 
-    fetchDisplayName();
+    fetchDisplayName().catch((error) => {
+      console.error("Failed to fetch display name", error);
+    });
 
     // Set up realtime subscription for display_name changes
     const channel = supabase

--- a/yap-frontend/src/components/LanguageSelector.tsx
+++ b/yap-frontend/src/components/LanguageSelector.tsx
@@ -293,7 +293,12 @@ export function LanguageSelector({
           targetLanguage: selectionState.targetLanguage,
         })
         .catch((e: unknown) => {
-          Sentry.captureException(e);
+          const message = e instanceof Error ? e.message : String(e);
+          // Network failures are expected on flaky mobile connections during
+          // onboarding; only report unexpected errors to Sentry.
+          if (!message.startsWith("Network error:")) {
+            Sentry.captureException(e);
+          }
         });
     }
   }, [selectionState, weapon]);

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -41,6 +41,12 @@ Sentry.init({
       }
     }
 
+    // Filter WASM streaming-compile failures caused by the network dropping
+    // mid-download. Message is unambiguous on its own (no stack needed).
+    if (message.startsWith("WebAssembly compilation aborted")) {
+      return null;
+    }
+
     return event;
   },
 


### PR DESCRIPTION
## Summary

Reviewed recent production Sentry issues in `javascript-react` and found three small, unambiguous fixes — no behavior changes to the app, just closing gaps in error handling / Sentry noise filtering:

- **`instrument.ts`**: `beforeSend` already filtered iOS's `"Load failed"` WASM-fetch errors, but not Chrome's equivalent message for the same underlying condition (network dropping mid-download during WASM streaming compilation). Added a filter for `"WebAssembly compilation aborted"`. Addresses **JAVASCRIPT-REACT-1F** and **JAVASCRIPT-REACT-2W**.
- **`App.tsx`**: `fetchDisplayName()` was invoked fire-and-forget with no `.catch()`. A dropped network request (e.g. Safari's `"Load failed"`) turned into a genuine unhandled promise rejection reported to Sentry. Added a `.catch()` that logs the error instead. Addresses **JAVASCRIPT-REACT-2R**.
- **`LanguageSelector.tsx`**: `cache_language_pack(...).catch(...)` reported every failure to Sentry unconditionally, including expected network errors during onboarding (often on flaky mobile connections while downloading a multi-MB language pack). The equivalent `load_language_pack` call site in `App.tsx` already filters these via an `isNetworkError` check — applied the same filter here. Addresses **JAVASCRIPT-REACT-1J**.

Other issues surveyed but left alone: the 4 remaining ServiceWorker install/update issues (JAVASCRIPT-REACT-2P/2G/2V) are already deliberately caught and filtered (`r.update().catch(...)` in `App.tsx` drops `TypeError`/`InvalidStateError` while online) — no unhandled-exception gap there, and adding more instrumentation would just be guesswork without a stack trace to confirm where they originate.

## Test plan

- [x] `pnpm exec tsc -b` — clean, no errors
- [x] `pnpm lint` — no new errors introduced by this diff (verified the two pre-existing lint errors that happen to sit in touched files, `App.tsx:235` and `LanguageSelector.tsx:88`, exist unchanged on the base branch)
- [ ] Manual verification in production (Sentry noise reduction is only observable over time)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Qxgd1rTrhcaitqd1p71nEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qxgd1rTrhcaitqd1p71nEs)_