### PR TITLE
dockerignore: keep the out/ files yap-frontend-rs embeds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,15 @@
 # Cache directories
 .cache/
 
-# Exclude everything in out/ except the rkyv files needed by include_bytes!
+# Exclude the bulky generated data in out/, but keep the files that Rust
+# builds embed: the rkyv packs (ai-backend include_bytes!) plus the hash and
+# showcase files (yap-frontend-rs include_str!/include_bytes!, compiled as a
+# dependency of yap-mcp).
 out/**/*.jsonl
 out/**/*.json
 out/**/*.hash
+!out/**/language_data.hash
+!out/**/showcase.json
 
 # Rust build artifacts
 target/


### PR DESCRIPTION
Fixes the yap-mcp Docker build failure in the last Deploy Production run: `couldn't read yap-frontend-rs/src/../../out/fra_for_eng/language_data.hash`. The root .dockerignore excluded all `out/**/*.hash` and `*.json`, but yap-frontend-rs (now compiled inside the yap-mcp image) embeds `language_data.hash` and `showcase.json` per course. Re-includes just those two names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMv3jpoiNzt3rg6sKehb7e