### PR TITLE
deploy: enforce a single yap-mcp machine

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,7 +203,15 @@ jobs:
           cache-to: type=registry,ref=registry.fly.io/yap-mcp:cache,mode=max
 
       - name: Deploy MCP server to Fly.io
-        run: flyctl deploy --config yap-mcp/fly.toml --image registry.fly.io/yap-mcp:${{ github.sha }}
+        run: flyctl deploy --config yap-mcp/fly.toml --ha=false --image registry.fly.io/yap-mcp:${{ github.sha }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_SECRET }}
+
+      # OAuth codes and MCP sessions live in memory, so the app must be exactly
+      # one machine. --ha=false stops deploys from creating a second machine;
+      # scale count destroys any extras that already exist (idempotent at 1).
+      - name: Enforce single MCP machine
+        run: flyctl scale count 1 --config yap-mcp/fly.toml --yes
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_SECRET }}
 


### PR DESCRIPTION
The deployed MCP server failed its end-to-end OAuth check: Fly's default second HA machine meant in-memory auth codes landed on one machine and token exchanges hit the other ("unknown or already-used code", interleaved). The deploy log confirms: "Creating a second machine for high availability".

OAuth codes and MCP sessions are deliberately in-memory (documented single-instance constraint), so: deploy with `--ha=false` and add an idempotent `flyctl scale count 1` step that also destroys the extra machine that already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMv3jpoiNzt3rg6sKehb7e