### PR TITLE
yap-mcp: approve connections on yap.town; serve at mcp.yap.town

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6846,7 +6846,6 @@ dependencies = [
  "chrono",
  "dotenvy",
  "env_logger",
- "html-escape",
  "http 1.3.1",
  "jsonwebtoken",
  "language-utils",

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -51,6 +51,7 @@ import { ResetPassword } from "@/pages/reset-password";
 import { ConfirmEmail } from "@/pages/confirm-email";
 import { AcceptInvite } from "@/pages/accept-invite";
 import { ForgotPassword } from "@/pages/forgot-password";
+import { Connect } from "./pages/connect";
 import { UserProfilePage } from "@/pages/user-profile";
 import { AboutPage } from "@/pages/about";
 import { LandingPage } from "@/pages/landing";
@@ -1287,6 +1288,7 @@ const router = createBrowserRouter([
       { path: "/confirm-email", element: <ConfirmEmail /> },
       { path: "/accept-invite", element: <AcceptInvite /> },
       { path: "/forgot-password", element: <ForgotPassword /> },
+      { path: "/connect", element: <Connect /> },
       { path: "/about", element: <AboutPage /> },
       {
         path: "/*",

--- a/yap-frontend/src/pages/connect.tsx
+++ b/yap-frontend/src/pages/connect.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import type { Session } from "@supabase/supabase-js";
+import { supabase } from "@/lib/supabase";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ThemeProvider } from "@/components/theme-provider";
+import { AuthDialog } from "@/components/auth-dialog";
+
+// The only MCP servers we will ever hand the user's session proof to. A
+// malicious link can't redirect approval anywhere else.
+const ALLOWED_MCP_ORIGINS = [
+  "https://mcp.yap.town",
+  "https://yap-mcp.fly.dev",
+  ...(import.meta.env.DEV ? ["http://localhost:8080", "http://localhost:8199"] : []),
+];
+
+/**
+ * OAuth approval page for MCP connectors (e.g. adding yap to claude.ai).
+ * The MCP server parks the client's authorize request and redirects here;
+ * the user signs in with their normal yap auth and approves, and we post
+ * their proof back to the server's /oauth/approve endpoint.
+ */
+export function Connect() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [session, setSession] = useState<Session | null>(null);
+  const [sessionLoaded, setSessionLoaded] = useState(false);
+  const [authOpen, setAuthOpen] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestId = searchParams.get("request");
+  const mcpOrigin = searchParams.get("mcp") ?? ALLOWED_MCP_ORIGINS[0];
+  const mcpOriginAllowed = ALLOWED_MCP_ORIGINS.includes(mcpOrigin);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+      setSessionLoaded(true);
+    });
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+    return () => subscription.unsubscribe();
+  }, []);
+
+  const handleConnect = async () => {
+    if (!session || !requestId) return;
+    setConnecting(true);
+    setError(null);
+    try {
+      const response = await fetch(`${mcpOrigin}/oauth/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          request_id: requestId,
+          access_token: session.access_token,
+        }),
+      });
+      const body = await response.json();
+      if (!response.ok) {
+        setError(
+          body.error_description ?? "Something went wrong — try connecting again.",
+        );
+        setConnecting(false);
+        return;
+      }
+      window.location.href = body.redirect;
+    } catch {
+      setError("Could not reach the connector server — try again.");
+      setConnecting(false);
+    }
+  };
+
+  const invalidReason = !requestId
+    ? "This connect link is missing its request. Start over from the app you're connecting."
+    : !mcpOriginAllowed
+      ? "This connect link points at a server yap.town doesn't recognize."
+      : null;
+
+  return (
+    <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
+      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <CardTitle className="text-2xl font-bold">Connect to yap.town</CardTitle>
+            <CardDescription>
+              An app wants to use your yap.town account through its connector.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {invalidReason ? (
+              <>
+                <div className="p-3 rounded text-sm bg-destructive/10 text-destructive border border-destructive/20">
+                  {invalidReason}
+                </div>
+                <Button onClick={() => navigate("/")} variant="outline" className="w-full">
+                  Go Home
+                </Button>
+              </>
+            ) : !sessionLoaded ? (
+              <p className="text-sm text-muted-foreground text-center">Loading…</p>
+            ) : !session ? (
+              <>
+                <p className="text-sm text-muted-foreground">
+                  Sign in to your yap.town account to continue.
+                </p>
+                <Button onClick={() => setAuthOpen(true)} className="w-full">
+                  Sign In
+                </Button>
+              </>
+            ) : (
+              <>
+                <div className="p-3 bg-muted rounded-md text-sm text-center">
+                  <p className="font-medium">{session.user.email}</p>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  This lets it see your deck and stats, quiz you on due cards, log
+                  your reviews, and add new words — everything syncs with the app.
+                </p>
+                {error && (
+                  <div className="p-3 rounded text-sm bg-destructive/10 text-destructive border border-destructive/20">
+                    {error}
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <Button
+                    onClick={() => navigate("/")}
+                    variant="outline"
+                    className="flex-1"
+                    disabled={connecting}
+                  >
+                    Cancel
+                  </Button>
+                  <Button onClick={handleConnect} className="flex-1" disabled={connecting}>
+                    {connecting ? "Connecting…" : "Connect"}
+                  </Button>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+        <AuthDialog open={authOpen} onOpenChange={setAuthOpen} defaultView="signin" />
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/yap-mcp/Cargo.toml
+++ b/yap-mcp/Cargo.toml
@@ -34,5 +34,4 @@ http = "1"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 sha2 = "0.10"
 base64 = "0.22"
-html-escape.workspace = true
 chacha20poly1305 = "0.10"

--- a/yap-mcp/README.md
+++ b/yap-mcp/README.md
@@ -77,8 +77,14 @@ RFC 9728 protected-resource metadata → RFC 8414 authorization-server metadata
 
 The OAuth layer is a thin shim over Supabase auth:
 
-- The `/oauth/authorize` page is a yap login form (email + password). A
-  successful login becomes a single-use authorization code.
+- `/oauth/authorize` parks the client's request and redirects to
+  `yap.town/connect`, where the user signs in with their normal yap auth
+  (same domain, so future passkeys work) and approves. The frontend posts
+  proof back to `/oauth/approve`, which mints the connector a **fresh**
+  Supabase session (admin generate_link + verify — reusing the browser's
+  session would entangle two devices in one refresh-token rotation family)
+  and hands back the redirect with a single-use authorization code. The
+  frontend hardcodes which MCP origins it will send proof to.
 - Tokens are MCP-scoped: we mint our own JWTs (`aud: yap-mcp`), with the
   user's Supabase session embedded **encrypted** (ChaCha20-Poly1305, key
   derived from `SUPABASE_JWT_SECRET`). The OAuth client never holds a raw
@@ -97,9 +103,16 @@ Per-user deck state is initialized lazily on first tool call (event fetch +
 replay) and cached; language packs load lazily per course and are shared
 across users.
 
-Env: `SUPABASE_JWT_SECRET` (required), `YAP_MCP_BASE_URL` (public URL, used in
-metadata and Host validation), `PORT`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`,
-`YAP_OUT_DIR`.
+Env: `SUPABASE_JWT_SECRET` and `SUPABASE_SERVICE_ROLE_KEY` (required),
+`YAP_MCP_BASE_URL` (public URL, used in metadata and Host validation),
+`YAP_FRONTEND_URL` (where /connect lives), `YAP_MCP_ALLOWED_HOSTS` (extra Host
+values, e.g. the fly.dev name behind the proxy), `PORT`, `SUPABASE_URL`,
+`SUPABASE_ANON_KEY`, `YAP_OUT_DIR`.
+
+The public domain `mcp.yap.town` is a Cloudflare Worker pass-through to
+`yap-mcp.fly.dev` (`proxy-worker/`; deploy with `wrangler deploy` from that
+directory). The worker approach exists because attaching a Workers custom
+domain auto-provisions DNS + TLS without needing Fly-side certificates.
 
 Deploy on Fly (first time: `flyctl launch --no-deploy --copy-config --config
 yap-mcp/fly.toml`, then set the secret):
@@ -110,14 +123,15 @@ flyctl deploy --config yap-mcp/fly.toml
 ```
 
 Then in claude.ai: Settings → Connectors → Add custom connector → URL
-`https://yap-mcp.fly.dev/mcp`. Claude discovers the OAuth endpoints, opens the
+`https://mcp.yap.town/mcp`. Claude discovers the OAuth endpoints, opens the
 yap login page, and connects.
 
 ## Current limitations
 
 - stdio mode's auth is service-role + email (fine for personal/local use);
   serve mode is the multi-user path.
-- Login is email + password only (matches the yap frontend's auth surface).
+- Approval uses whatever auth the yap.town frontend supports (today email +
+  password; passkeys would work there when added).
 - Listening cards can be quizzed only as text in a chat client.
 - No challenge generation (translation/transcription exercises) yet; the chat
   LLM is expected to quiz the user itself, e.g. using `get_sentences`.

--- a/yap-mcp/fly.toml
+++ b/yap-mcp/fly.toml
@@ -1,5 +1,6 @@
 # Deploy from the repo root: `flyctl deploy --config yap-mcp/fly.toml`
-# Requires secrets: SUPABASE_JWT_SECRET (flyctl secrets set ...)
+# Requires secrets (flyctl secrets set ...): SUPABASE_JWT_SECRET,
+# SUPABASE_SERVICE_ROLE_KEY (mints connector sessions on approval)
 
 app = 'yap-mcp'
 primary_region = 'ord'
@@ -9,7 +10,10 @@ dockerfile = 'yap-mcp/Dockerfile'
 
 [env]
 PORT = '8080'
-YAP_MCP_BASE_URL = 'https://yap-mcp.fly.dev'
+YAP_MCP_BASE_URL = 'https://mcp.yap.town'
+# The Cloudflare Worker proxy in front of mcp.yap.town forwards with the
+# fly.dev Host header, so both must pass Host validation.
+YAP_MCP_ALLOWED_HOSTS = 'yap-mcp.fly.dev'
 
 [http_service]
 internal_port = 8080

--- a/yap-mcp/proxy-worker/index.js
+++ b/yap-mcp/proxy-worker/index.js
@@ -1,0 +1,9 @@
+// mcp.yap.town -> yap-mcp.fly.dev pass-through proxy.
+// Exists so users see a yap.town domain; streams SSE bodies unchanged.
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    url.hostname = "yap-mcp.fly.dev";
+    return fetch(new Request(url, request));
+  },
+};

--- a/yap-mcp/proxy-worker/wrangler.toml
+++ b/yap-mcp/proxy-worker/wrangler.toml
@@ -1,0 +1,4 @@
+name = "yap-mcp-proxy"
+main = "index.js"
+compatibility_date = "2026-07-01"
+routes = [{ pattern = "mcp.yap.town", custom_domain = true }]

--- a/yap-mcp/smoke/remote_oauth.py
+++ b/yap-mcp/smoke/remote_oauth.py
@@ -6,7 +6,7 @@ Usage:
     python3 yap-mcp/smoke/remote_oauth.py target/debug/yap-mcp serve
 
 Drives the whole claude.ai connector flow against a locally spawned server:
-OAuth discovery -> dynamic client registration -> login page -> PKCE code
+OAuth discovery -> dynamic client registration -> frontend approve -> PKCE code
 exchange -> refresh -> authenticated streamable-HTTP MCP calls. Asserts the
 security properties: PKCE enforced, codes single-use, redirect URIs pinned,
 tokens MCP-scoped (raw Supabase JWTs rejected at /mcp), embedded Supabase
@@ -152,23 +152,54 @@ auth_params = {
     "response_type": "code", "client_id": client_id, "redirect_uri": REDIRECT_URI,
     "state": "st4te", "code_challenge": challenge, "code_challenge_method": "S256",
 }
-status, _, body = req("GET", f"{BASE}/oauth/authorize?" + urllib.parse.urlencode(auth_params))
-check("authorize page", status == 200 and "Sign in" in body and 'name="code_challenge"' in body)
+ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVlYXJ3enFvdHBmb2RlcnBmcnF4Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDgyMTUwOTIsImV4cCI6MjA2Mzc5MTA5Mn0.BmnDrHtD-THaSLHO9VE2X-PO6B-z9OkbxzjeIinN6b8"
+
+def start_authorize():
+    """GET /oauth/authorize -> parse the yap.town/connect redirect -> request id."""
+    status, headers, _ = req("GET", f"{BASE}/oauth/authorize?" + urllib.parse.urlencode(auth_params),
+                             follow=False)
+    location = headers.get("location", "")
+    q = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
+    return status, location, q.get("request", [None])[0], q.get("mcp", [None])[0]
+
+status, location, request_id, mcp_origin = start_authorize()
+check("authorize redirects to frontend /connect",
+      status in (302, 303) and "/connect?" in location, location[:140])
+check("redirect carries request id + mcp origin", bool(request_id) and mcp_origin == BASE,
+      f"mcp={mcp_origin}")
 
 bad = dict(auth_params, redirect_uri="https://evil.example/cb")
-status, _, body = req("GET", f"{BASE}/oauth/authorize?" + urllib.parse.urlencode(bad))
+status, _, body = req("GET", f"{BASE}/oauth/authorize?" + urllib.parse.urlencode(bad), follow=False)
 check("authorize rejects unregistered redirect", status == 400, body)
 
-status, _, body = req("POST", f"{BASE}/oauth/authorize",
-                      body=dict(auth_params, email=TEST_EMAIL, password="wrong-password"), form=True)
-check("wrong password re-renders", status == 200 and "Wrong email or password" in body)
+# The user's proof: a real Supabase session for the test account
+status, _, body = req("POST", f"{SUPABASE_URL}/auth/v1/token?grant_type=password",
+                      headers={"apikey": ANON_KEY},
+                      body={"email": TEST_EMAIL, "password": TEST_PASSWORD})
+user_access_token = json.loads(body)["access_token"]
 
-status, headers, body = req("POST", f"{BASE}/oauth/authorize",
-                            body=dict(auth_params, email=TEST_EMAIL, password=TEST_PASSWORD),
-                            form=True, follow=False)
-location = headers.get("location", "")
-check("login redirects with code", status in (302, 303) and location.startswith(REDIRECT_URI), location[:120])
-q = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
+# Approving with a garbage session must fail (and burns the request id)
+status, _, body = req("POST", f"{BASE}/oauth/approve",
+                      body={"request_id": request_id, "access_token": "garbage"})
+check("approve rejects invalid session", status == 401, body)
+
+status, _, body = req("POST", f"{BASE}/oauth/approve",
+                      body={"request_id": request_id, "access_token": user_access_token})
+check("request id is single-use", status == 400, body)
+
+def approve():
+    """Fresh authorize + approve as the test user; returns the auth code."""
+    _, _, request_id, _ = start_authorize()
+    status, _, body = req("POST", f"{BASE}/oauth/approve",
+                          body={"request_id": request_id, "access_token": user_access_token})
+    resp = json.loads(body)
+    return status, resp
+
+status, resp = approve()
+check("approve returns claude redirect",
+      status == 200 and resp.get("redirect", "").startswith(REDIRECT_URI),
+      json.dumps(resp)[:140])
+q = urllib.parse.parse_qs(urllib.parse.urlparse(resp["redirect"]).query)
 code = q["code"][0]
 check("state round-trips", q.get("state") == ["st4te"])
 
@@ -179,11 +210,9 @@ status, _, body = req("POST", asm["token_endpoint"], form=True, body={
 })
 check("wrong PKCE verifier rejected", status == 400, body)
 
-# The code was consumed by the failed attempt (single use) — do the flow again
-status, headers, _ = req("POST", f"{BASE}/oauth/authorize",
-                         body=dict(auth_params, email=TEST_EMAIL, password=TEST_PASSWORD),
-                         form=True, follow=False)
-code = urllib.parse.parse_qs(urllib.parse.urlparse(headers["location"]).query)["code"][0]
+# The code was consumed by the failed attempt (single use) — approve again
+_, resp = approve()
+code = urllib.parse.parse_qs(urllib.parse.urlparse(resp["redirect"]).query)["code"][0]
 
 status, _, body = req("POST", asm["token_endpoint"], form=True, body={
     "grant_type": "authorization_code", "code": code, "redirect_uri": REDIRECT_URI,

--- a/yap-mcp/src/remote.rs
+++ b/yap-mcp/src/remote.rs
@@ -3,8 +3,12 @@
 //!
 //! The OAuth layer is a thin shim over Supabase auth: access tokens ARE
 //! Supabase user JWTs (verified with the project JWT secret, exactly like
-//! yap-ai-backend does), token refresh proxies to Supabase, and the authorize
-//! page logs the user into their yap account with email + password. All event
+//! yap-ai-backend does), token refresh proxies to Supabase, and authorization
+//! happens on the yap.town frontend: /oauth/authorize parks the request and
+//! redirects to yap.town/connect, where the user signs in with their normal
+//! yap auth (passkey-ready, same domain) and approves; the frontend then
+//! posts their proof back to /oauth/approve and we mint the connector a
+//! fresh Supabase session of its own. All event
 //! reads/writes then happen as the user themself, inside RLS. The only
 //! server-side OAuth state is the in-flight authorization codes; client
 //! registrations are encoded as signed client_ids, so restarts don't break
@@ -21,7 +25,7 @@ use axum::{
     extract::{Query, State},
     http::{StatusCode, header},
     middleware::Next,
-    response::{Html, IntoResponse, Redirect, Response},
+    response::{IntoResponse, Redirect, Response},
     routing::{get, post},
 };
 use base64::Engine as _;
@@ -59,6 +63,14 @@ pub struct RemoteConfig {
     /// The Supabase project JWT secret, used to verify user access tokens and
     /// to sign client_ids.
     pub jwt_secret: String,
+    /// Service role key, used only to mint a fresh Supabase session for the
+    /// connector when the user approves on the frontend.
+    pub service_role_key: String,
+    /// The yap.town frontend origin hosting the /connect approval page.
+    pub frontend_url: String,
+    /// Extra hostnames to accept in the Host header (e.g. the fly.dev name
+    /// when the public domain is proxied in front of it).
+    pub extra_allowed_hosts: Vec<String>,
     pub out_dir: PathBuf,
 }
 
@@ -80,6 +92,21 @@ impl RemoteConfig {
             std::env::var("SUPABASE_ANON_KEY").unwrap_or_else(|_| DEFAULT_ANON_KEY.to_string());
         let jwt_secret = std::env::var("SUPABASE_JWT_SECRET")
             .context("SUPABASE_JWT_SECRET env var required (verifies user tokens)")?;
+        let service_role_key = std::env::var("SUPABASE_SERVICE_ROLE_KEY")
+            .context("SUPABASE_SERVICE_ROLE_KEY env var required (mints connector sessions)")?;
+        let frontend_url = std::env::var("YAP_FRONTEND_URL")
+            .unwrap_or_else(|_| "https://yap.town".to_string())
+            .trim_end_matches('/')
+            .to_string();
+        let extra_allowed_hosts = std::env::var("YAP_MCP_ALLOWED_HOSTS")
+            .map(|hosts| {
+                hosts
+                    .split(',')
+                    .map(|host| host.trim().to_string())
+                    .filter(|host| !host.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default();
         let out_dir = std::env::var("YAP_OUT_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../out")));
@@ -89,6 +116,9 @@ impl RemoteConfig {
             supabase_url,
             supabase_anon_key,
             jwt_secret,
+            service_role_key,
+            frontend_url,
+            extra_allowed_hosts,
             out_dir,
         })
     }
@@ -113,6 +143,16 @@ struct PendingCode {
     created: Instant,
 }
 
+/// An authorize request parked while the user signs in and approves it on the
+/// yap.town frontend.
+struct PendingAuth {
+    client_id: String,
+    redirect_uri: String,
+    state: Option<String>,
+    code_challenge: String,
+    created: Instant,
+}
+
 pub struct RemoteApp {
     pub config: RemoteConfig,
     http: reqwest::Client,
@@ -122,6 +162,7 @@ pub struct RemoteApp {
     token_cipher: ChaCha20Poly1305,
     users: Mutex<HashMap<String, Arc<Mutex<YapState>>>>,
     codes: Mutex<HashMap<String, PendingCode>>,
+    pending_auth: Mutex<HashMap<String, PendingAuth>>,
 }
 
 impl RemoteApp {
@@ -137,6 +178,7 @@ impl RemoteApp {
             token_cipher,
             users: Mutex::new(HashMap::new()),
             codes: Mutex::new(HashMap::new()),
+            pending_auth: Mutex::new(HashMap::new()),
         }
     }
 
@@ -230,10 +272,8 @@ pub async fn serve(app: Arc<RemoteApp>) -> anyhow::Result<()> {
             get(authorization_server_metadata),
         )
         .route("/oauth/register", post(register))
-        .route(
-            "/oauth/authorize",
-            get(authorize_page).post(authorize_submit),
-        )
+        .route("/oauth/authorize", get(authorize_page))
+        .route("/oauth/approve", post(approve))
         .route("/oauth/token", post(token))
         .route("/health", get(|| async { "ok" }))
         .with_state(app.clone());
@@ -268,6 +308,7 @@ fn allowed_hosts(config: &RemoteConfig) -> Vec<String> {
             hosts.push(format!("{host}:{port}"));
         }
     }
+    hosts.extend(config.extra_allowed_hosts.iter().cloned());
     hosts
 }
 
@@ -509,8 +550,6 @@ struct AuthorizeParams {
     code_challenge: String,
     #[serde(default)]
     code_challenge_method: Option<String>,
-    #[serde(default)]
-    scope: Option<String>,
 }
 
 fn validate_authorize(app: &RemoteApp, params: &AuthorizeParams) -> Result<(), String> {
@@ -531,6 +570,10 @@ fn validate_authorize(app: &RemoteApp, params: &AuthorizeParams) -> Result<(), S
     }
 }
 
+/// Start the flow: validate the client's request, park it, and send the user
+/// to the yap.town frontend to sign in and approve (auth lives on the main
+/// domain so passkeys can work there). The frontend posts back to
+/// /oauth/approve.
 async fn authorize_page(
     State(app): State<Arc<RemoteApp>>,
     Query(params): Query<AuthorizeParams>,
@@ -538,37 +581,35 @@ async fn authorize_page(
     if let Err(e) = validate_authorize(&app, &params) {
         return (StatusCode::BAD_REQUEST, e).into_response();
     }
-    Html(login_page(&params, None)).into_response()
-}
 
-#[derive(Deserialize)]
-struct LoginForm {
-    email: String,
-    password: String,
-    response_type: String,
-    client_id: String,
-    redirect_uri: String,
-    #[serde(default)]
-    state: Option<String>,
-    code_challenge: String,
-    #[serde(default)]
-    code_challenge_method: Option<String>,
-    #[serde(default)]
-    scope: Option<String>,
-}
-
-impl LoginForm {
-    fn params(&self) -> AuthorizeParams {
-        AuthorizeParams {
-            response_type: self.response_type.clone(),
-            client_id: self.client_id.clone(),
-            redirect_uri: self.redirect_uri.clone(),
-            state: self.state.clone(),
-            code_challenge: self.code_challenge.clone(),
-            code_challenge_method: self.code_challenge_method.clone(),
-            scope: self.scope.clone(),
-        }
+    let request_id = random_token();
+    {
+        let mut pending = app.pending_auth.lock().await;
+        pending.retain(|_, p| p.created.elapsed() < CODE_TTL);
+        pending.insert(
+            request_id.clone(),
+            PendingAuth {
+                client_id: params.client_id.clone(),
+                redirect_uri: params.redirect_uri.clone(),
+                state: params.state.clone(),
+                code_challenge: params.code_challenge.clone(),
+                created: Instant::now(),
+            },
+        );
     }
+
+    let mut url = match reqwest::Url::parse(&format!("{}/connect", app.config.frontend_url)) {
+        Ok(url) => url,
+        Err(_) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, "bad frontend url").into_response();
+        }
+    };
+    url.query_pairs_mut()
+        .append_pair("request", &request_id)
+        // Which whitelisted MCP origin the frontend should post approval to
+        // (lets the same page work against a locally-run server in dev).
+        .append_pair("mcp", &app.config.base_url);
+    Redirect::to(url.as_str()).into_response()
 }
 
 #[derive(Deserialize)]
@@ -584,54 +625,121 @@ struct SupabaseUser {
     id: String,
 }
 
-async fn authorize_submit(
-    State(app): State<Arc<RemoteApp>>,
-    Form(form): Form<LoginForm>,
-) -> Response {
-    let params = form.params();
-    if let Err(e) = validate_authorize(&app, &params) {
-        return (StatusCode::BAD_REQUEST, e).into_response();
-    }
+/// Claims of a Supabase user access token (as opposed to the tokens we mint).
+#[derive(Deserialize)]
+struct SupabaseAccessClaims {
+    sub: String,
+    email: String,
+}
 
-    let resp = app
+fn verify_supabase_token(app: &RemoteApp, token: &str) -> Option<SupabaseAccessClaims> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_audience(&["authenticated"]);
+    jsonwebtoken::decode::<SupabaseAccessClaims>(
+        token,
+        &DecodingKey::from_secret(app.config.jwt_secret.as_bytes()),
+        &validation,
+    )
+    .ok()
+    .map(|data| data.claims)
+}
+
+/// Mint a fresh Supabase session for the connector via the admin
+/// generate_link + verify dance (the same trick the impersonation tool uses).
+/// The browser's own session must not be reused: two devices sharing one
+/// refresh-token rotation family would invalidate each other.
+async fn mint_session(app: &RemoteApp, email: &str) -> anyhow::Result<SupabaseSession> {
+    let service_key = &app.config.service_role_key;
+    let link: serde_json::Value = app
         .http
         .post(format!(
-            "{}/auth/v1/token?grant_type=password",
+            "{}/auth/v1/admin/generate_link",
             app.config.supabase_url
         ))
-        .header("apikey", &app.config.supabase_anon_key)
-        .json(&json!({ "email": form.email, "password": form.password }))
+        .header("apikey", service_key)
+        .header("Authorization", format!("Bearer {service_key}"))
+        .json(&json!({ "type": "magiclink", "email": email }))
         .send()
-        .await;
-    let session: SupabaseSession = match resp {
-        Ok(resp) if resp.status().is_success() => match resp.json().await {
-            Ok(session) => session,
-            Err(e) => {
-                log::error!("failed to parse Supabase session: {e}");
-                return Html(login_page(
-                    &params,
-                    Some("Something went wrong — try again."),
-                ))
-                .into_response();
-            }
-        },
-        Ok(_) => {
-            return Html(login_page(&params, Some("Wrong email or password."))).into_response();
-        }
-        Err(e) => {
-            log::error!("Supabase login request failed: {e}");
-            return Html(login_page(
-                &params,
-                Some("Something went wrong — try again."),
-            ))
-            .into_response();
-        }
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let token_hash = link["hashed_token"]
+        .as_str()
+        .or_else(|| link["properties"]["hashed_token"].as_str())
+        .context("generate_link response missing hashed_token")?;
+
+    let session: SupabaseSession = app
+        .http
+        .post(format!("{}/auth/v1/verify", app.config.supabase_url))
+        .header("apikey", &app.config.supabase_anon_key)
+        .json(&json!({ "type": "magiclink", "token_hash": token_hash }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    Ok(session)
+}
+
+#[derive(Deserialize)]
+struct ApproveRequest {
+    request_id: String,
+    /// The signed-in user's Supabase access token, proving who is approving.
+    access_token: String,
+}
+
+/// Called by the yap.town /connect page when the user approves. Exchanges
+/// their proof of identity for an authorization code and tells the frontend
+/// where to send the user next.
+async fn approve(State(app): State<Arc<RemoteApp>>, Json(req): Json<ApproveRequest>) -> Response {
+    let Some(pending) = app.pending_auth.lock().await.remove(&req.request_id) else {
+        return oauth_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "unknown or expired connect request — start over from your MCP client",
+        );
+    };
+    if pending.created.elapsed() > CODE_TTL {
+        return oauth_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "connect request expired — start over from your MCP client",
+        );
+    }
+    let Some(claims) = verify_supabase_token(&app, &req.access_token) else {
+        return oauth_error(
+            StatusCode::UNAUTHORIZED,
+            "access_denied",
+            "your yap session is invalid or expired — sign in again",
+        );
     };
 
-    let code = {
-        let bytes: [u8; 32] = rand::rng().random();
-        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    let session = match mint_session(&app, &claims.email).await {
+        Ok(session) => session,
+        Err(e) => {
+            log::error!("failed to mint connector session for {}: {e:#}", claims.sub);
+            return oauth_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "could not create a session — try again",
+            );
+        }
     };
+    if session.user.id != claims.sub {
+        log::error!(
+            "minted session user {} does not match approver {}",
+            session.user.id,
+            claims.sub
+        );
+        return oauth_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            "could not create a session — try again",
+        );
+    }
+
+    let code = random_token();
     {
         let mut codes = app.codes.lock().await;
         codes.retain(|_, pending| pending.created.elapsed() < CODE_TTL);
@@ -639,23 +747,28 @@ async fn authorize_submit(
             code.clone(),
             PendingCode {
                 session,
-                code_challenge: params.code_challenge.clone(),
-                client_id: params.client_id.clone(),
-                redirect_uri: params.redirect_uri.clone(),
+                code_challenge: pending.code_challenge,
+                client_id: pending.client_id,
+                redirect_uri: pending.redirect_uri.clone(),
                 created: Instant::now(),
             },
         );
     }
 
-    let mut url = match reqwest::Url::parse(&params.redirect_uri) {
+    let mut url = match reqwest::Url::parse(&pending.redirect_uri) {
         Ok(url) => url,
         Err(_) => return (StatusCode::BAD_REQUEST, "invalid redirect_uri").into_response(),
     };
     url.query_pairs_mut().append_pair("code", &code);
-    if let Some(state) = &params.state {
+    if let Some(state) = &pending.state {
         url.query_pairs_mut().append_pair("state", state);
     }
-    Redirect::to(url.as_str()).into_response()
+    Json(json!({ "redirect": url.as_str() })).into_response()
+}
+
+fn random_token() -> String {
+    let bytes: [u8; 32] = rand::rng().random();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
 }
 
 #[derive(Deserialize)]
@@ -774,71 +887,4 @@ fn oauth_error(status: StatusCode, error: &str, description: &str) -> Response {
         Json(json!({ "error": error, "error_description": description })),
     )
         .into_response()
-}
-
-fn login_page(params: &AuthorizeParams, error: Option<&str>) -> String {
-    let attr = |v: &str| html_escape::encode_double_quoted_attribute(v).into_owned();
-    let hidden = |name: &str, value: &str| {
-        format!(
-            r#"<input type="hidden" name="{name}" value="{}">"#,
-            attr(value)
-        )
-    };
-    let mut hidden_fields = String::new();
-    hidden_fields.push_str(&hidden("response_type", &params.response_type));
-    hidden_fields.push_str(&hidden("client_id", &params.client_id));
-    hidden_fields.push_str(&hidden("redirect_uri", &params.redirect_uri));
-    if let Some(state) = &params.state {
-        hidden_fields.push_str(&hidden("state", state));
-    }
-    hidden_fields.push_str(&hidden("code_challenge", &params.code_challenge));
-    if let Some(method) = &params.code_challenge_method {
-        hidden_fields.push_str(&hidden("code_challenge_method", method));
-    }
-    if let Some(scope) = &params.scope {
-        hidden_fields.push_str(&hidden("scope", scope));
-    }
-    let error_html = error
-        .map(|e| format!(r#"<p class="error">{}</p>"#, html_escape::encode_text(e)))
-        .unwrap_or_default();
-
-    format!(
-        r#"<!doctype html>
-<html>
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Connect to yap.town</title>
-<style>
-  body {{ font-family: system-ui, sans-serif; background: #faf7f0; display: flex;
-         justify-content: center; align-items: center; min-height: 100vh; margin: 0; }}
-  .card {{ background: white; border-radius: 12px; padding: 2rem; width: 320px;
-           box-shadow: 0 4px 24px rgba(0,0,0,0.08); }}
-  h1 {{ font-size: 1.2rem; margin: 0 0 0.5rem; }}
-  p {{ color: #555; font-size: 0.9rem; margin: 0 0 1.25rem; }}
-  label {{ display: block; font-size: 0.8rem; color: #333; margin-bottom: 0.25rem; }}
-  input[type=email], input[type=password] {{ width: 100%; box-sizing: border-box;
-    padding: 0.5rem; margin-bottom: 1rem; border: 1px solid #ddd; border-radius: 6px; }}
-  button {{ width: 100%; padding: 0.6rem; background: #1a1a1a; color: white;
-    border: none; border-radius: 6px; font-size: 0.95rem; cursor: pointer; }}
-  .error {{ color: #c0392b; }}
-</style>
-</head>
-<body>
-  <div class="card">
-    <h1>Connect to yap.town</h1>
-    <p>Sign in to let this app do reviews, add words, and read your stats.</p>
-    {error_html}
-    <form method="post" action="/oauth/authorize">
-      {hidden_fields}
-      <label for="email">Email</label>
-      <input type="email" id="email" name="email" required autofocus>
-      <label for="password">Password</label>
-      <input type="password" id="password" name="password" required>
-      <button type="submit">Sign in &amp; connect</button>
-    </form>
-  </div>
-</body>
-</html>"#
-    )
 }


### PR DESCRIPTION
Two changes so the connector is presentable and passkey-ready:

- **Auth moves to yap.town.** `/oauth/authorize` parks the request and redirects to a new `yap.town/connect` page (standalone Card page in house style) where the user signs in with their normal yap auth and approves. The page posts proof to `/oauth/approve`, which mints the connector a fresh Supabase session (admin `generate_link` + `verify`, same trick as impersonation — the browser's own session can't be reused without entangling refresh-token rotation). The frontend hardcodes the MCP origins it will send proof to. The hosted login form is gone.
- **Public domain `mcp.yap.town`** via a checked-in Cloudflare Worker pass-through (`yap-mcp/proxy-worker/`, already deployed — custom domain auto-provisioned DNS + TLS). `fly.toml` flips the base URL; the fly.dev Host stays allowed since the proxy forwards with it.

Verified in an isolated clone: clippy/fmt clean, frontend tsc + production build pass, and the full rewritten smoke (`yap-mcp/smoke/remote_oauth.py`) is ALL PASS — including the new approve flow exercising real `generate_link` session minting, request-id single-use, and invalid-session rejection.

Needs on Fly (done): `SUPABASE_SERVICE_ROLE_KEY` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMv3jpoiNzt3rg6sKehb7e