### PR TITLE
Directory prep: annotations, search/fetch, unlock_cards, legal pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ The public dictionary lives at `/d/` and is built as a static site that gets cop
 1. **Rust** (`generate-dictionary-data`): Reads `.rkyv` language pack archives → outputs JSON to `static-site/src/data/`. Produces a lightweight index JSON per course (for listing pages) and individual per-page JSON files (with full sentence data including cross-linked glosses). Data is split this way because loading everything into one JSON would OOM Node during Astro build.
 2. **Astro** (`static-site`): Reads the JSON and generates ~178k static HTML pages with Tailwind CSS v4 (`@tailwindcss/vite`). Output goes directly to `yap-frontend/public/d/` via Astro's `outDir` config.
 3. **Vite**: A custom plugin (`dictionaryStaticPlugin` in `yap-frontend/vite.config.ts`) intercepts `/d/` routes before the SPA fallback, serving the pre-built static HTML instead.
-4. **Vercel**: Serves the static dictionary pages alongside the SPA. The CI workflow builds dictionary data → Astro → then the Vite frontend.
+4. **Cloudflare**: Serves the static dictionary pages alongside the SPA. The CI workflow builds dictionary data → Astro → then the Vite frontend.
 
 Key details:
 - Sentences are cross-linked: each gram in a sentence links to its dictionary page and includes a native-language gloss
@@ -139,6 +139,7 @@ python3 yap-mcp/smoke/remote_oauth.py target/debug/yap-mcp serve
 - Use `uv` for Python dependency management in NLP components
 - Use `pnpm` for JavaScript/TypeScript dependencies
 - All target-language text in yap-frontend should use the TargetLanguage component 
+- The privacy policy at `yap-frontend/src/pages/privacy.tsx` (yap.town/privacy) must stay accurate: whenever a change is privacy-affecting — a new third-party service, new data collected or stored, telemetry changes, a new place user content is sent — update the policy (and its effective date) in the same PR.
 - For spacing between siblings in yap-frontend, prefer parent-driven spacing — Tailwind `gap-*` on a flex/grid parent (e.g. the Card component's gap) or a `space-y-*` wrapper — over per-child margins. Keep spacing uniform at the container level.
 
 Final most important note: We do not have to worry about backwards compatibility with respect to our API. We mostly only have to worry about it for our events, in yap-frontend-rs/src/deck_event, as those types are serialized to disk. We do not worry about it with our API. Rust functions, traits, structs... except for those implicated by yap-frontend-rs/src/deck_event, do not worry! All the code is here, it's basically a monorepo, so we can always fix all the breakage and that's always better than leaving scar tissue from old code. If that makes sense to you, please start conversations by saying "I will maintain backwards compatibility with regards to our structs that get serialized, but make all the changes necessary across the codebase to write clean and minimal code without worrying about backwards compatibility in our internal APIs."

--- a/generate-dictionary-data/src/main.rs
+++ b/generate-dictionary-data/src/main.rs
@@ -234,11 +234,7 @@ fn get_definition_preview(sense: &Sense) -> String {
 }
 
 fn course_slug(course: &Course) -> String {
-    format!(
-        "{}-to-{}",
-        course.target_language.to_string().to_lowercase(),
-        course.native_language.to_string().to_lowercase()
-    )
+    course.dictionary_slug()
 }
 
 fn course_dir_name(course: &Course) -> String {
@@ -249,23 +245,7 @@ fn course_dir_name(course: &Course) -> String {
     )
 }
 
-fn text_to_slug(text: &str) -> String {
-    text.chars()
-        .map(|c| {
-            if c.is_alphanumeric() {
-                c.to_lowercase().next().unwrap_or(c)
-            } else if c == ' ' || c == '\'' || c == '-' || c == '\u{2019}' {
-                '-'
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>()
-        .replace("--", "-")
-        .trim_matches('-')
-        .trim_matches('_')
-        .to_string()
-}
+use language_utils::dictionary_entry_slug as text_to_slug;
 
 fn load_language_pack(rkyv_path: &Path) -> Result<LanguagePack> {
     let bytes = std::fs::read(rkyv_path)

--- a/language-utils/src/lib.rs
+++ b/language-utils/src/lib.rs
@@ -3326,6 +3326,37 @@ impl Course {
     pub fn teaches_new_writing_system(&self) -> bool {
         self.native_language.writing_system() != self.target_language.writing_system()
     }
+
+    /// URL slug of this course on the public dictionary site
+    /// (yap.town/d/<slug>/), e.g. "french-to-english".
+    pub fn dictionary_slug(&self) -> String {
+        format!(
+            "{}-to-{}",
+            self.target_language.to_string().to_lowercase(),
+            self.native_language.to_string().to_lowercase()
+        )
+    }
+}
+
+/// URL slug of a dictionary entry on the public dictionary site, derived from
+/// its display text. Colliding slugs get a `-2`/`-3`... suffix at site
+/// generation time, which this function alone cannot know about.
+pub fn dictionary_entry_slug(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            if c.is_alphanumeric() {
+                c.to_lowercase().next().unwrap_or(c)
+            } else if c == ' ' || c == '\'' || c == '-' || c == '\u{2019}' {
+                '-'
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .replace("--", "-")
+        .trim_matches('-')
+        .trim_matches('_')
+        .to_string()
 }
 
 pub const COURSES: &[Course] = &[

--- a/static-site/src/components/Author.astro
+++ b/static-site/src/components/Author.astro
@@ -9,9 +9,9 @@ if (now.getMonth() < birthDate.getMonth() || (now.getMonth() === birthDate.getMo
 
 <div class="mt-10 pt-6 border-t">
   <div class="flex items-start gap-4 text-sm">
-    <img src="/selfie.webp" alt="Andre Popovitch" class="w-14 h-14 rounded-full object-cover shrink-0" />
+    <img src="/selfie.webp" alt="André Popovitch" class="w-14 h-14 rounded-full object-cover shrink-0" />
     <div>
-      <p class="font-medium text-foreground">Andre Popovitch</p>
+      <p class="font-medium text-foreground">André Popovitch</p>
       <p class="text-muted-foreground mt-1">
         {age}-year-old software developer in San Francisco, sometimes known as
         <a href="https://twitter.com/chadnauseam" class="text-accent-foreground hover:underline">chad nauseam</a>.

--- a/static-site/src/layouts/Layout.astro
+++ b/static-site/src/layouts/Layout.astro
@@ -30,7 +30,7 @@ const { title, description, courseSlug } = Astro.props;
       <slot />
       <footer class="mt-12 pt-6 border-t text-center text-xs text-muted-foreground">
         <p>
-          Yap.Town is created by <a href="https://twitter.com/chadnauseam" class="underline">Andre Popovitch</a>.
+          Yap.Town is created by <a href="https://twitter.com/chadnauseam" class="underline">André Popovitch</a>.
           <a href="https://github.com/yaptown/yap" class="underline ml-1">GitHub</a>
           {' | '}
           <a href="https://discord.gg/mpgqfsH" class="underline">Discord</a>

--- a/yap-frontend-rs/src/dictionary.rs
+++ b/yap-frontend-rs/src/dictionary.rs
@@ -119,43 +119,7 @@ impl Deck {
                     0
                 };
 
-                let card = CardIndicator::WrittenGram { gram: *spur_gram };
-                let is_in_deck = matches!(self.cards.get(&card), Some(CardData::Added { .. }));
-
-                let (prefix, morphology) =
-                    compute_word_prefix_and_morphology(&resolved_gram, gram_def, target_language);
-
-                let entry = match gram_def {
-                    GramDefinition::Dictionary(dict_def) => GramDictionaryEntry {
-                        display_text,
-                        frequency_index,
-                        is_in_deck,
-                        is_phrase: false,
-                        prefix,
-                        morphology,
-                        definition: GramDictionaryDefinition::Dictionary {
-                            definitions: dict_def.definitions.clone(),
-                        },
-                        target_language,
-                    },
-                    GramDefinition::Phrasebook(pb_def) => GramDictionaryEntry {
-                        display_text,
-                        frequency_index,
-                        is_in_deck,
-                        is_phrase: true,
-                        prefix,
-                        morphology,
-                        definition: GramDictionaryDefinition::Phrasebook {
-                            meaning: pb_def.meaning.clone(),
-                            target_language_example: Some(pb_def.target_language_example.clone())
-                                .filter(|s| !s.is_empty()),
-                            native_language_example: Some(pb_def.native_language_example.clone())
-                                .filter(|s| !s.is_empty()),
-                        },
-                        target_language,
-                    },
-                };
-
+                let entry = self.gram_dictionary_entry(frequency_index)?;
                 Some(((relevance, frequency_index), entry))
             })
             .collect();
@@ -167,6 +131,58 @@ impl Deck {
         entries.sort_by_key(|(key, _)| *key);
 
         entries.into_iter().map(|(_, entry)| entry).collect()
+    }
+
+    /// Build the dictionary entry at a frequency index (None when out of
+    /// range or the gram has no definition).
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+    pub fn gram_dictionary_entry(&self, frequency_index: usize) -> Option<GramDictionaryEntry> {
+        let language_pack = &self.context.language_pack;
+        let target_language = self.context.course.target_language;
+        let (spur_gram, _freq) = language_pack
+            .gram_frequencies
+            .entries
+            .get_index(frequency_index)?;
+        let gram_def = language_pack.gram_definitions.get(spur_gram)?;
+        let resolved_gram = language_pack.resolve_gram(spur_gram);
+        let display_text = resolved_gram.to_display_string(target_language);
+
+        let card = CardIndicator::WrittenGram { gram: *spur_gram };
+        let is_in_deck = matches!(self.cards.get(&card), Some(CardData::Added { .. }));
+
+        let (prefix, morphology) =
+            compute_word_prefix_and_morphology(&resolved_gram, gram_def, target_language);
+
+        Some(match gram_def {
+            GramDefinition::Dictionary(dict_def) => GramDictionaryEntry {
+                display_text,
+                frequency_index,
+                is_in_deck,
+                is_phrase: false,
+                prefix,
+                morphology,
+                definition: GramDictionaryDefinition::Dictionary {
+                    definitions: dict_def.definitions.clone(),
+                },
+                target_language,
+            },
+            GramDefinition::Phrasebook(pb_def) => GramDictionaryEntry {
+                display_text,
+                frequency_index,
+                is_in_deck,
+                is_phrase: true,
+                prefix,
+                morphology,
+                definition: GramDictionaryDefinition::Phrasebook {
+                    meaning: pb_def.meaning.clone(),
+                    target_language_example: Some(pb_def.target_language_example.clone())
+                        .filter(|s| !s.is_empty()),
+                    native_language_example: Some(pb_def.native_language_example.clone())
+                        .filter(|s| !s.is_empty()),
+                },
+                target_language,
+            },
+        })
     }
 
     /// Get the total number of gram dictionary entries (for "Showing X of Y" display)

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -4,7 +4,7 @@ mod audio;
 mod challenge;
 mod deck_event;
 pub mod deck_selection;
-mod dictionary;
+pub mod dictionary;
 mod directories;
 mod human_audio;
 mod language_pack;

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -54,6 +54,9 @@ import { ForgotPassword } from "@/pages/forgot-password";
 import { Connect } from "./pages/connect";
 import { UserProfilePage } from "@/pages/user-profile";
 import { AboutPage } from "@/pages/about";
+import { PrivacyPage } from "@/pages/privacy";
+import { TermsPage } from "@/pages/terms";
+import { McpDocsPage } from "@/pages/mcp-docs";
 import { LandingPage } from "@/pages/landing";
 import { NotFoundPage } from "@/pages/not-found";
 import { SentenceListsPage } from "@/pages/sentence-lists";
@@ -1290,6 +1293,9 @@ const router = createBrowserRouter([
       { path: "/forgot-password", element: <ForgotPassword /> },
       { path: "/connect", element: <Connect /> },
       { path: "/about", element: <AboutPage /> },
+      { path: "/privacy", element: <PrivacyPage /> },
+      { path: "/terms", element: <TermsPage /> },
+      { path: "/mcp", element: <McpDocsPage /> },
       {
         path: "/*",
         element: <AppMain />,

--- a/yap-frontend/src/components/about.tsx
+++ b/yap-frontend/src/components/about.tsx
@@ -5,7 +5,7 @@ export function About() {
     <div className="text-center text-xs text-muted-foreground mt-4">
       yap.town is created by{" "}
       <a href="https://twitter.com/chadnauseam" className="underline">
-        Andre Popovitch
+        André Popovitch
       </a>
       .{" "}
       <a href="https://github.com/yaptown/yap" className="underline">
@@ -18,6 +18,14 @@ export function About() {
       {" | "}
       <Link to="/about" className="underline">
         About
+      </Link>
+      {" | "}
+      <Link to="/privacy" className="underline">
+        Privacy
+      </Link>
+      {" | "}
+      <Link to="/terms" className="underline">
+        Terms
       </Link>
     </div>
   );

--- a/yap-frontend/src/pages/about.tsx
+++ b/yap-frontend/src/pages/about.tsx
@@ -79,7 +79,7 @@ export function AboutPage() {
                 href="https://twitter.com/chadnauseam"
                 className="underline text-foreground"
               >
-                Andre Popovitch
+                André Popovitch
               </a>
               .{" "}
             </p>

--- a/yap-frontend/src/pages/landing.tsx
+++ b/yap-frontend/src/pages/landing.tsx
@@ -262,7 +262,7 @@ function MockFlashcard() {
           <span className="rounded-md border border-border/60 px-2 py-0.5 text-sm font-medium">
             25
           </span>
-          <span>Andre</span>
+          <span>André</span>
           <Moon className="h-5 w-5" />
         </div>
       </div>

--- a/yap-frontend/src/pages/mcp-docs.tsx
+++ b/yap-frontend/src/pages/mcp-docs.tsx
@@ -1,0 +1,175 @@
+import { Card } from "@/components/ui/card";
+import { Link } from "react-router-dom";
+
+const CONTACT_EMAIL = "support@yap.town";
+const SECURITY_EMAIL = "security@yap.town";
+const CONNECTOR_URL = "https://mcp.yap.town/mcp";
+
+export function McpDocsPage() {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex flex-col items-center justify-center p-4 gap-4">
+        <div className="flex items-center mb-4 gap-2 w-full">
+          <Link to="/" className="text-2xl">
+            ←
+          </Link>
+          <h1 className="text-3xl font-bold">Yap for AI Assistants</h1>
+        </div>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <div className="px-2 space-y-2">
+            <p>
+              Yap has a connector (an{" "}
+              <a
+                href="https://modelcontextprotocol.io"
+                className="underline text-foreground"
+              >
+                MCP server
+              </a>
+              ) that lets AI assistants like Claude and ChatGPT use your
+              yap.town account. Do your reviews in the middle of a
+              conversation, ask what a word means and add it to your deck, or
+              have the assistant quiz you with sentences you can actually
+              understand — everything syncs with the app.
+            </p>
+            <p>
+              The connector URL is{" "}
+              <code className="text-foreground">{CONNECTOR_URL}</code>.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            What it can do
+          </h2>
+          <div className="px-2 space-y-2">
+            <ul className="list-disc pl-5 space-y-1">
+              <li>List the flashcards you're due to review</li>
+              <li>
+                Quiz you with example sentences made of words you already know,
+                and log your reviews — real spaced-repetition scheduling, same
+                as in the app
+              </li>
+              <li>Search the dictionary of your course</li>
+              <li>Add new words and phrases to your deck</li>
+              <li>Release cards you've set aside in lockup</li>
+              <li>Show your stats: streak, XP, deck size, comprehension tier</li>
+            </ul>
+            <p>
+              That's the full list. It can't change your course, delete cards,
+              edit your profile, or touch your account settings.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Connecting
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              <span className="text-foreground">Claude:</span> Settings →
+              Connectors → Add custom connector, and paste the connector URL.
+            </p>
+            <p>
+              <span className="text-foreground">ChatGPT:</span> Settings → Apps
+              &amp; Connectors, enable Developer mode under Advanced settings,
+              then add the connector URL (requires a paid ChatGPT plan).
+            </p>
+            <p>
+              Either way, you'll be sent to yap.town to sign in and approve the
+              connection. Approve it only if you initiated it. To disconnect,
+              remove the connector in the assistant's settings.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Privacy
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              A connected assistant can read your deck, stats, and dictionary,
+              and can add cards and log reviews. It never receives your yap
+              password or a general-purpose credential — the connection uses
+              scoped tokens that only work with the connector. Your
+              conversations with the assistant are handled by its provider
+              under its own privacy policy; see also{" "}
+              <Link to="/privacy" className="underline text-foreground">
+                yap's privacy policy
+              </Link>
+              .
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Troubleshooting
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              <span className="text-foreground">
+                "Could not detect course" or an empty deck:
+              </span>{" "}
+              the connector follows the course you use in the app. Open{" "}
+              <a href="https://yap.town" className="underline text-foreground">
+                yap.town
+              </a>
+              , pick a course, and add a few words first.
+            </p>
+            <p>
+              <span className="text-foreground">Connection fails:</span> make
+              sure you completed the sign-in and pressed Connect on the
+              yap.town approval page, signed in to the account you meant to
+              use. Then remove the connector in the assistant and add it again.
+            </p>
+            <p>
+              <span className="text-foreground">Stale data:</span> the
+              connector re-syncs with your account within about 20 seconds. If
+              a review you just did in the app isn't reflected, ask the
+              assistant to check again.
+            </p>
+            <p>
+              <span className="text-foreground">"Too many requests":</span> the
+              server rate-limits sign-in attempts per address; wait a minute
+              and retry.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Support and security
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              Problems or questions:{" "}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="underline text-foreground"
+              >
+                {CONTACT_EMAIL}
+              </a>
+              .
+            </p>
+            <p>
+              Found a security vulnerability in the connector or in yap? Please
+              report it privately to{" "}
+              <a
+                href={`mailto:${SECURITY_EMAIL}`}
+                className="underline text-foreground"
+              >
+                {SECURITY_EMAIL}
+              </a>{" "}
+              and give us a chance to fix it before disclosing. We read and
+              investigate every report.
+            </p>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/yap-frontend/src/pages/privacy.tsx
+++ b/yap-frontend/src/pages/privacy.tsx
@@ -1,0 +1,179 @@
+import { Card } from "@/components/ui/card";
+import { Link } from "react-router-dom";
+
+const CONTACT_EMAIL = "support@yap.town";
+
+export function PrivacyPage() {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex flex-col items-center justify-center p-4 gap-4">
+        <div className="flex items-center mb-4 gap-2 w-full">
+          <Link to="/" className="text-2xl">
+            ←
+          </Link>
+          <h1 className="text-3xl font-bold">Privacy Policy</h1>
+        </div>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <div className="px-2 space-y-2">
+            <p>
+              Yap.Town is a language-learning app built and operated by André
+              Popovitch. The short version: we collect what's needed to teach
+              you a language and sync your progress between devices, we don't
+              sell your data, we don't run ads, and there are no advertising or
+              analytics trackers on the site.
+            </p>
+            <p className="text-sm">Effective July 9, 2026.</p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            What we collect
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              <span className="text-foreground">Account.</span> Your email
+              address and password (stored hashed by our auth provider). You
+              can optionally add a display name and bio, which are visible to
+              other users.
+            </p>
+            <p>
+              <span className="text-foreground">Learning activity.</span> The
+              words you add, your reviews and ratings, streaks, XP, and course
+              selection. This is the heart of the app: it's stored on our
+              servers so your progress syncs between devices, and a copy lives
+              on your device so yap works offline.
+            </p>
+            <p>
+              <span className="text-foreground">Social.</span> Who you follow
+              and who follows you.
+            </p>
+            <p>
+              <span className="text-foreground">Practice audio and answers.</span>{" "}
+              When you use pronunciation practice, your microphone recording is
+              sent to our server and to AI providers to generate feedback. When
+              you type answers to challenges, the answer is sent to AI
+              providers for grading. These are processed to give you feedback,
+              not to build a profile of you.
+            </p>
+            <p>
+              <span className="text-foreground">Technical.</span> We use Sentry
+              for error and performance monitoring so we can fix crashes. Error
+              reports can include your IP address and device information, and a
+              sample of sessions is recorded as a session replay (a
+              reconstruction of what the app showed and where you clicked) to
+              help us debug.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Services we rely on
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              We don't run our own data centers. These providers process data
+              on our behalf, each only for the purpose listed:
+            </p>
+            <ul className="list-disc pl-5 space-y-1">
+              <li>Supabase — accounts, authentication, and the database</li>
+              <li>Cloudflare — hosting and content delivery</li>
+              <li>Fly.io — backend servers</li>
+              <li>Sentry — error tracking and session replay</li>
+              <li>Resend — sending emails, such as notifications</li>
+              <li>Amazon Web Services — some backend processing and storage</li>
+              <li>
+                AI providers (Google, OpenAI, ElevenLabs) — grading practice
+                answers, pronunciation feedback, and generating audio
+              </li>
+            </ul>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            AI assistants you connect
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              You can connect AI assistants like Claude or ChatGPT to your yap
+              account through our{" "}
+              <Link to="/mcp" className="underline text-foreground">
+                connector
+              </Link>
+              . If you do, that assistant can see your deck, stats, and
+              dictionary, and can add cards and log reviews on your behalf —
+              only after you approve the connection while signed in. Your
+              conversations with the assistant happen in that provider's
+              product and are governed by its privacy policy, not this one; we
+              only receive the requests the assistant makes to your account.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Retention and deletion
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              We keep your data for as long as your account exists. To delete
+              your account and its synced data, email{" "}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="underline text-foreground"
+              >
+                {CONTACT_EMAIL}
+              </a>{" "}
+              from your account's email address — we'll remove it from our live
+              systems promptly, and from backups as they rotate out. The
+              offline copy on your device is under your control; clearing your
+              browser's site data removes it.
+            </p>
+            <p>
+              You can also email us to access, export, or correct your data.
+              If you're covered by GDPR, CCPA, or similar laws, these are the
+              rights they give you, and we honor them for everyone regardless
+              of where you live.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Children
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              Yap.Town is not directed at children under 13, and you must be at
+              least 13 to create an account. If you believe a child under 13
+              has an account, contact us and we'll delete it.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Changes and contact
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              If this policy changes, we'll update this page and its effective
+              date; if the changes are significant we'll say so in the app.
+              Questions, requests, or concerns:{" "}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="underline text-foreground"
+              >
+                {CONTACT_EMAIL}
+              </a>
+              .
+            </p>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/yap-frontend/src/pages/terms.tsx
+++ b/yap-frontend/src/pages/terms.tsx
@@ -1,0 +1,138 @@
+import { Card } from "@/components/ui/card";
+import { Link } from "react-router-dom";
+
+const CONTACT_EMAIL = "support@yap.town";
+
+export function TermsPage() {
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex flex-col items-center justify-center p-4 gap-4">
+        <div className="flex items-center mb-4 gap-2 w-full">
+          <Link to="/" className="text-2xl">
+            ←
+          </Link>
+          <h1 className="text-3xl font-bold">Terms of Service</h1>
+        </div>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <div className="px-2 space-y-2">
+            <p>
+              Yap.Town is a free language-learning app built and operated by
+              André Popovitch. By using it you agree to these terms — they're
+              short, please actually read them.
+            </p>
+            <p className="text-sm">Effective July 9, 2026.</p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            The service
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              Yap.Town teaches languages with spaced repetition and
+              comprehensible input. It's under active development: features may
+              change, break, or be removed, and we don't promise the service
+              will always be available or that your data will never be lost —
+              though we work hard to keep it safe and synced.
+            </p>
+            <p>
+              AI-generated feedback (grading, pronunciation help, and the like)
+              can be wrong. It's a study aid, not an authority.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Your account
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              Keep your credentials to yourself; you're responsible for what
+              happens under your account. You must be at least 13 years old to
+              have one.
+            </p>
+            <p>
+              Your display name and bio are visible to others — keep them
+              civil. Don't impersonate people, don't harass anyone, don't try
+              to break or overload the service, and don't use it for anything
+              unlawful. We may suspend or remove accounts that do.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Your data and our content
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              Your learning data is yours. We process it to run the service, as
+              described in the{" "}
+              <Link to="/privacy" className="underline text-foreground">
+                privacy policy
+              </Link>
+              , and you can take it with you or delete it by contacting us.
+            </p>
+            <p>
+              The app's source code is available on{" "}
+              <a
+                href="https://github.com/yaptown/yap"
+                className="underline text-foreground"
+              >
+                GitHub
+              </a>{" "}
+              under its license. Example sentences and audio come from public
+              corpora and other sources credited in the app.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            Connected apps
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              If you connect an AI assistant or other app to your account (see{" "}
+              <Link to="/mcp" className="underline text-foreground">
+                the connector
+              </Link>
+              ), it acts on your behalf: reviews it logs and cards it adds are
+              treated as yours. Only connect apps you trust, and we may revoke
+              access for connected apps that abuse the service.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="max-w-2xl w-full p-8 gap-2 text-muted-foreground">
+          <h2 className="text-xl font-semibold text-foreground mb-2">
+            The legal bits
+          </h2>
+          <div className="px-2 space-y-2">
+            <p>
+              Yap.Town is provided "as is", free of charge, without warranties
+              of any kind. To the maximum extent permitted by law, we are not
+              liable for damages arising from your use of the service. Nothing
+              in these terms limits liability that can't legally be limited.
+            </p>
+            <p>
+              We may update these terms; if we make significant changes we'll
+              say so in the app, and continuing to use yap after that means you
+              accept the new terms. Questions:{" "}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="underline text-foreground"
+              >
+                {CONTACT_EMAIL}
+              </a>
+              .
+            </p>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/yap-mcp/README.md
+++ b/yap-mcp/README.md
@@ -35,7 +35,21 @@ real course entry is rejected; the server never guesses.
   `comprehensible_sentences` list otherwise composed only of words the user
   knows, and an `other_sentences` list sampled from everything containing the
   gram regardless of difficulty.
+- `unlock_cards` — release the next batch from lockup (the app's "review N
+   more cards" offer), via the deck's own `get_release_offer`; reviewing a
+   locked card also unlocks it. `get_due_cards` reports `cards_in_lockup`.
 - `get_stats` — streak, XP, review counts, deck size, tier, recent days.
+- `search` / `fetch` — the standard browse/cite pair (required by ChatGPT for
+  deep research and connector validation). `search` returns dictionary entry
+  pages as `{id, title, url}`; `fetch` takes an `id`
+  (`"<course-slug>:<frequency-index>"`) and returns the entry as readable
+  text with a citable `url` into the public dictionary at `yap.town/d/`, plus
+  the exact gram in `metadata`. URLs are best-effort: colliding display texts
+  get a numeric suffix at site build time we can't reproduce, so rare
+  homographs may 404 (sampled hit rate: 39/39).
+
+All tools carry MCP annotations (`title`, `readOnlyHint`/`destructiveHint`,
+etc.), which both the Anthropic and OpenAI directories require.
 
 ## How it works
 
@@ -136,3 +150,34 @@ yap login page, and connects.
 - No challenge generation (translation/transcription exercises) yet; the chat
   LLM is expected to quiz the user itself, e.g. using `get_sentences`.
 - OAuth codes and MCP sessions are in-memory: run exactly one instance.
+- Public OAuth endpoints are rate-limited per client IP (fixed 60s windows);
+  cached per-user deck state is evicted after 6h idle.
+
+## Directory review account
+
+Reviewers for the Anthropic/OpenAI directories get the throwaway account
+`yap-mcp-test@popovit.ch` (see `smoke/`). To reset and re-populate it with a
+believable deck and review history:
+
+```bash
+set -a; source .env; set +a
+YAP_TEST_USER_PASSWORD=<reviewer password> python3 yap-mcp/smoke/setup_test_user.py
+YAP_USER_EMAIL=yap-mcp-test@popovit.ch python3 yap-mcp/smoke/seed_test_user.py target/debug/yap-mcp
+```
+
+Public docs for end users live at `yap.town/mcp`; privacy policy at
+`yap.town/privacy`.
+
+## When Supabase moves to asymmetric signing keys
+
+The current setup verifies user access tokens and signs/encrypts our own MCP
+tokens with the shared `SUPABASE_JWT_SECRET`. Migration is mechanical, and the
+`generate_link` session-minting is unaffected:
+
+1. Verify Supabase user tokens via the project JWKS (RS256/ES256) instead of
+   the HS256 secret (`verify_supabase_token`).
+2. Introduce a dedicated `MCP_TOKEN_SECRET` for signing our access/refresh
+   tokens (`issue_tokens`, `verify_access_token`, `verify_refresh_token`) —
+   they were only ever verified by us.
+3. Derive the session-encryption key from that same new secret
+   (`RemoteApp::new`). Existing connections re-authorize once.

--- a/yap-mcp/smoke/seed_test_user.py
+++ b/yap-mcp/smoke/seed_test_user.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Populate the throwaway test account with a believable deck + review history.
+
+Directory reviewers (Anthropic/OpenAI) get this account's credentials; a blank
+deck would make half the tools look broken. Run setup_test_user.py first to
+reset the account, then this to seed it via the real stdio server (so every
+event has the exact byte shape the app writes):
+
+    set -a; source .env; set +a
+    python3 yap-mcp/smoke/setup_test_user.py
+    YAP_USER_EMAIL=yap-mcp-test@popovit.ch python3 yap-mcp/smoke/seed_test_user.py target/debug/yap-mcp
+
+Leaves the account with ~15 common French cards: most reviewed once with a
+mix of ratings (so stats/history look lived-in), a few never reviewed (so
+get_due_cards always has something for the reviewer to grade).
+"""
+import json
+import os
+import subprocess
+import sys
+import threading
+
+BIN = sys.argv[1]
+
+# Common French words; the last few stay unreviewed so they sit in the due queue.
+WORDS = [
+    "bonjour", "merci", "chat", "chien", "maison", "eau", "manger", "parler",
+    "rouge", "grand", "petit", "oui", "non", "ami", "livre",
+]
+RATINGS = ["good", "easy", "good", "hard", "good", "again", "easy", "good", "good", "hard"]
+
+proc = subprocess.Popen(
+    [BIN], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    text=True, env=os.environ,
+)
+
+def pump_stderr():
+    for line in proc.stderr:
+        sys.stderr.write("[server] " + line)
+
+threading.Thread(target=pump_stderr, daemon=True).start()
+
+next_id = [0]
+
+def send(method, params=None, notification=False):
+    msg = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        msg["params"] = params
+    if not notification:
+        next_id[0] += 1
+        msg["id"] = next_id[0]
+    proc.stdin.write(json.dumps(msg) + "\n")
+    proc.stdin.flush()
+    if notification:
+        return None
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            raise SystemExit("server closed stdout")
+        resp = json.loads(line)
+        if resp.get("id") == next_id[0]:
+            return resp
+
+def tool(name, arguments):
+    resp = send("tools/call", {"name": name, "arguments": arguments})
+    result = resp.get("result", resp.get("error"))
+    is_error = isinstance(result, dict) and result.get("isError", False)
+    texts = [b["text"] for b in result.get("content", []) if b.get("type") == "text"]
+    return is_error, "\n".join(texts) or json.dumps(result)
+
+send("initialize", {"protocolVersion": "2025-06-18", "capabilities": {},
+                    "clientInfo": {"name": "seed", "version": "0"}})
+send("notifications/initialized", notification=True)
+
+grams = []
+for word in WORDS:
+    err, body = tool("search_dictionary", {"query": word, "limit": 1})
+    assert not err, f"search '{word}' failed: {body}"
+    results = json.loads(body)["results"]
+    if not results:
+        print(f"no dictionary match for '{word}', skipping")
+        continue
+    top = results[0]
+    grams.append((top["language"], top["gram"], top["display_text"]))
+
+language = grams[0][0]
+err, body = tool("add_cards", {"language": language, "grams": [g for _, g, _ in grams]})
+assert not err, f"add_cards failed: {body}"
+added = json.loads(body)
+print(f"added {len(added['added'])} cards ({len(added['already_in_deck'])} already present)")
+
+err, body = tool("get_due_cards", {"limit": len(RATINGS)})
+assert not err, f"get_due_cards failed: {body}"
+due = json.loads(body)["cards"]
+for entry, rating in zip(due, RATINGS):
+    err, body = tool("log_review", {
+        "language": entry["language"], "card": entry["card"], "rating": rating,
+    })
+    assert not err, f"log_review failed: {body}"
+    print(f"reviewed {entry.get('display_text', '?')}: {rating}")
+
+err, body = tool("get_stats", {})
+assert not err, f"get_stats failed: {body}"
+print("\nfinal stats:\n" + body)
+
+proc.stdin.close()
+proc.wait(timeout=10)
+print("\nseed complete")

--- a/yap-mcp/smoke/setup_test_user.py
+++ b/yap-mcp/smoke/setup_test_user.py
@@ -54,6 +54,13 @@ else:
     test_id = created["id"]
     print(f"created test user: {test_id}")
 
+# Directory reviewers sign in with this account on yap.town, so give it a
+# stable password when one is provided.
+password = os.environ.get("YAP_TEST_USER_PASSWORD")
+if password:
+    req("PUT", f"/auth/v1/admin/users/{test_id}", {"password": password})
+    print("password set from YAP_TEST_USER_PASSWORD")
+
 # Wipe any prior test events for repeatability
 req("DELETE", f"/rest/v1/events?user_id=eq.{test_id}")
 

--- a/yap-mcp/src/remote.rs
+++ b/yap-mcp/src/remote.rs
@@ -153,6 +153,25 @@ struct PendingAuth {
     created: Instant,
 }
 
+/// A user's cached deck state plus when it was last touched, so idle users
+/// can be evicted (the state is cheap to rebuild from events on their next
+/// request; the heavyweight language packs are shared and stay cached).
+struct UserSlot {
+    state: Arc<Mutex<YapState>>,
+    last_used: Instant,
+}
+
+/// Evict a user's cached state after this much inactivity.
+const USER_STATE_IDLE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+
+/// One fixed rate-limit window on a public endpoint, keyed by (endpoint, ip).
+struct RateWindow {
+    started: Instant,
+    count: u32,
+}
+
+const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
 pub struct RemoteApp {
     pub config: RemoteConfig,
     http: reqwest::Client,
@@ -160,9 +179,10 @@ pub struct RemoteApp {
     /// Encrypts the Supabase session embedded in the tokens we mint, so the
     /// OAuth client never holds a raw Supabase credential.
     token_cipher: ChaCha20Poly1305,
-    users: Mutex<HashMap<String, Arc<Mutex<YapState>>>>,
+    users: Mutex<HashMap<String, UserSlot>>,
     codes: Mutex<HashMap<String, PendingCode>>,
     pending_auth: Mutex<HashMap<String, PendingAuth>>,
+    rate_limits: Mutex<HashMap<(&'static str, String), RateWindow>>,
 }
 
 impl RemoteApp {
@@ -179,7 +199,22 @@ impl RemoteApp {
             users: Mutex::new(HashMap::new()),
             codes: Mutex::new(HashMap::new()),
             pending_auth: Mutex::new(HashMap::new()),
+            rate_limits: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Fixed-window per-IP rate limit. Returns false when the caller should
+    /// get a 429. Best-effort: the IP comes from proxy headers, so this stops
+    /// floods and accidents, not a determined attacker with many addresses.
+    async fn allow_rate(&self, endpoint: &'static str, ip: String, limit: u32) -> bool {
+        let mut limits = self.rate_limits.lock().await;
+        limits.retain(|_, w| w.started.elapsed() < RATE_LIMIT_WINDOW);
+        let window = limits.entry((endpoint, ip)).or_insert(RateWindow {
+            started: Instant::now(),
+            count: 0,
+        });
+        window.count += 1;
+        window.count <= limit
     }
 
     fn encrypt(&self, plaintext: &str) -> String {
@@ -209,9 +244,16 @@ impl RemoteApp {
     /// Get (or lazily initialize) the deck state for an authenticated user,
     /// refreshing the bearer token it uses for Supabase calls.
     pub async fn state_for_user(&self, user: &AuthedUser) -> anyhow::Result<Arc<Mutex<YapState>>> {
-        if let Some(slot) = self.users.lock().await.get(&user.user_id).cloned() {
-            slot.lock().await.set_bearer(user.bearer.clone());
-            return Ok(slot);
+        {
+            let mut users = self.users.lock().await;
+            users.retain(|_, slot| slot.last_used.elapsed() < USER_STATE_IDLE_TTL);
+            if let Some(slot) = users.get_mut(&user.user_id) {
+                slot.last_used = Instant::now();
+                let state = slot.state.clone();
+                drop(users);
+                state.lock().await.set_bearer(user.bearer.clone());
+                return Ok(state);
+            }
         }
 
         // Initialize outside the map lock so one user's slow first load (event
@@ -225,8 +267,35 @@ impl RemoteApp {
         let state = YapState::for_user(supabase, user.user_id.clone(), &self.packs).await?;
         let slot = Arc::new(Mutex::new(state));
         let mut users = self.users.lock().await;
-        Ok(users.entry(user.user_id.clone()).or_insert(slot).clone())
+        Ok(users
+            .entry(user.user_id.clone())
+            .or_insert(UserSlot {
+                state: slot,
+                last_used: Instant::now(),
+            })
+            .state
+            .clone())
     }
+}
+
+/// Best-effort client IP for rate limiting: Cloudflare's header when we're
+/// behind the mcp.yap.town proxy, Fly's when hit directly, else unknown (one
+/// shared bucket — still bounds total damage).
+fn client_ip(headers: &axum::http::HeaderMap) -> String {
+    for header in ["cf-connecting-ip", "fly-client-ip"] {
+        if let Some(ip) = headers.get(header).and_then(|v| v.to_str().ok()) {
+            return ip.to_string();
+        }
+    }
+    "unknown".to_string()
+}
+
+fn rate_limited() -> Response {
+    oauth_error(
+        StatusCode::TOO_MANY_REQUESTS,
+        "slow_down",
+        "too many requests from your address — wait a minute and try again",
+    )
 }
 
 /// Run the remote server. Serves OAuth + metadata publicly and the MCP
@@ -501,8 +570,12 @@ struct RegistrationRequest {
 
 async fn register(
     State(app): State<Arc<RemoteApp>>,
+    headers: axum::http::HeaderMap,
     Json(req): Json<RegistrationRequest>,
 ) -> Response {
+    if !app.allow_rate("register", client_ip(&headers), 30).await {
+        return rate_limited();
+    }
     if req.redirect_uris.is_empty() {
         return oauth_error(
             StatusCode::BAD_REQUEST,
@@ -576,8 +649,12 @@ fn validate_authorize(app: &RemoteApp, params: &AuthorizeParams) -> Result<(), S
 /// /oauth/approve.
 async fn authorize_page(
     State(app): State<Arc<RemoteApp>>,
+    headers: axum::http::HeaderMap,
     Query(params): Query<AuthorizeParams>,
 ) -> Response {
+    if !app.allow_rate("authorize", client_ip(&headers), 60).await {
+        return rate_limited();
+    }
     if let Err(e) = validate_authorize(&app, &params) {
         return (StatusCode::BAD_REQUEST, e).into_response();
     }
@@ -692,7 +769,14 @@ struct ApproveRequest {
 /// Called by the yap.town /connect page when the user approves. Exchanges
 /// their proof of identity for an authorization code and tells the frontend
 /// where to send the user next.
-async fn approve(State(app): State<Arc<RemoteApp>>, Json(req): Json<ApproveRequest>) -> Response {
+async fn approve(
+    State(app): State<Arc<RemoteApp>>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<ApproveRequest>,
+) -> Response {
+    if !app.allow_rate("approve", client_ip(&headers), 30).await {
+        return rate_limited();
+    }
     let Some(pending) = app.pending_auth.lock().await.remove(&req.request_id) else {
         return oauth_error(
             StatusCode::BAD_REQUEST,
@@ -786,7 +870,14 @@ struct TokenRequest {
     refresh_token: Option<String>,
 }
 
-async fn token(State(app): State<Arc<RemoteApp>>, Form(req): Form<TokenRequest>) -> Response {
+async fn token(
+    State(app): State<Arc<RemoteApp>>,
+    headers: axum::http::HeaderMap,
+    Form(req): Form<TokenRequest>,
+) -> Response {
+    if !app.allow_rate("token", client_ip(&headers), 120).await {
+        return rate_limited();
+    }
     match req.grant_type.as_str() {
         "authorization_code" => {
             let Some(code) = &req.code else {

--- a/yap-mcp/src/server.rs
+++ b/yap-mcp/src/server.rs
@@ -17,11 +17,15 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use language_utils::{Gram, Language, SpurGram, language_pack::LanguagePack};
+use language_utils::{
+    Course, Gram, Language, SpurGram, dictionary_entry_slug, language_pack::LanguagePack,
+};
 use lasso::Spur;
 use weapon::data_model::{EventStore, EventType};
 use yap_frontend_rs::{
-    CardIndicator, Context, Deck, DeckEvent, LanguageEvent, LanguageEventContent, Rating,
+    CardIndicator, CardSummary, Context, Deck, DeckEvent, LanguageEvent, LanguageEventContent,
+    Rating,
+    dictionary::{GramDictionaryDefinition, GramDictionaryEntry},
 };
 
 use crate::deck::{PackCache, build_deck, detect_course, insert_rows, new_store};
@@ -304,6 +308,68 @@ impl YapState {
         }
         out
     }
+
+    /// Sample sentences containing an interned gram: up to `count` composed
+    /// only of words the user already knows, and up to `count` more from the
+    /// whole corpus, each rendered with translations and attribution.
+    fn sample_sentences(&mut self, interned: SpurGram, count: usize) -> SampledSentences {
+        let comprehensible_pool = {
+            let deck = self.deck();
+            let comprehensible = deck.comprehensible_written_grams(false);
+            deck.context()
+                .language_pack
+                .comprehensible_sentences(Some(&interned), |g| comprehensible.contains(g))
+        };
+
+        use rand::seq::IndexedRandom as _;
+        let chosen_comprehensible: Vec<Spur> = comprehensible_pool
+            .choose_multiple(&mut rand::rng(), count)
+            .copied()
+            .collect();
+
+        let pack = self.pack();
+        let all_containing = pack
+            .sentences_containing_gram_index
+            .get(&interned)
+            .cloned()
+            .unwrap_or_default();
+        let other_pool: Vec<Spur> = all_containing
+            .iter()
+            .copied()
+            .filter(|sentence| !chosen_comprehensible.contains(sentence))
+            .collect();
+        let chosen_other: Vec<Spur> = other_pool
+            .choose_multiple(&mut rand::rng(), count)
+            .copied()
+            .collect();
+
+        let render = |sentence: &Spur| {
+            let text = pack.string_rodeo.resolve(sentence);
+            let translations: Vec<&str> = pack
+                .translations
+                .get(sentence)
+                .map(|ts| ts.iter().map(|t| pack.string_rodeo.resolve(t)).collect())
+                .unwrap_or_default();
+            json!({
+                "text": text,
+                "translations": translations,
+                "sources": self.sentence_sources(sentence),
+            })
+        };
+        SampledSentences {
+            comprehensible: chosen_comprehensible.iter().map(render).collect(),
+            other: chosen_other.iter().map(render).collect(),
+            total_comprehensible: comprehensible_pool.len(),
+            total_containing: all_containing.len(),
+        }
+    }
+}
+
+struct SampledSentences {
+    comprehensible: Vec<serde_json::Value>,
+    other: Vec<serde_json::Value>,
+    total_comprehensible: usize,
+    total_containing: usize,
 }
 
 fn ok_json(value: serde_json::Value) -> CallToolResult {
@@ -312,8 +378,75 @@ fn ok_json(value: serde_json::Value) -> CallToolResult {
     )])
 }
 
+/// Like ok_json, but also sets MCP structured content — ChatGPT's search/fetch
+/// contract wants results both ways.
+fn ok_json_structured(value: serde_json::Value) -> CallToolResult {
+    let mut result = CallToolResult::success(vec![ContentBlock::text(
+        serde_json::to_string_pretty(&value).expect("json serializes"),
+    )]);
+    result.structured_content = Some(value);
+    result
+}
+
+/// The public dictionary, canonical regardless of where the server runs.
+const DICTIONARY_BASE_URL: &str = "https://yap.town/d";
+
+/// A short native-language gloss for titles/citations.
+fn entry_gloss(entry: &GramDictionaryEntry) -> String {
+    match entry.definition() {
+        GramDictionaryDefinition::Dictionary { definitions } => definitions
+            .iter()
+            .take(2)
+            .map(|d| d.native.clone())
+            .collect::<Vec<_>>()
+            .join("; "),
+        GramDictionaryDefinition::Phrasebook { meaning, .. } => meaning,
+    }
+}
+
+fn entry_title(entry: &GramDictionaryEntry) -> String {
+    let gloss = entry_gloss(entry);
+    if gloss.is_empty() {
+        entry.display_text()
+    } else {
+        format!("{} — {}", entry.display_text(), gloss)
+    }
+}
+
+/// Stable id for the search/fetch pair, e.g. "french-to-english:42".
+fn entry_id(course: &Course, entry: &GramDictionaryEntry) -> String {
+    format!("{}:{}", course.dictionary_slug(), entry.frequency_index())
+}
+
+/// Best-effort public URL of the entry's dictionary page. Entries whose
+/// display text collides with another's get a numeric suffix at site build
+/// time that we can't reproduce here, so rare homographs may 404.
+fn entry_url(course: &Course, display_text: &str) -> String {
+    format!(
+        "{DICTIONARY_BASE_URL}/{}/{}/",
+        course.dictionary_slug(),
+        dictionary_entry_slug(display_text)
+    )
+}
+
 fn error(message: impl Into<String>) -> CallToolResult {
     CallToolResult::error(vec![ContentBlock::text(message.into())])
+}
+
+/// The card shape shared by get_due_cards and unlock_cards: everything the
+/// LLM needs to quiz the user and pass the card back to log_review.
+fn card_summary_json(language: &serde_json::Value, summary: &CardSummary) -> serde_json::Value {
+    let indicator = summary.card_indicator();
+    json!({
+        "language": language,
+        "card": serde_json::to_value(&indicator).expect("card serializes"),
+        "text": summary.card_text(),
+        "subtitle": summary.card_subtitle(),
+        "kind": card_kind(&indicator),
+        "fsrs_state": summary.state(),
+        "due": chrono::DateTime::from_timestamp_millis(summary.due_timestamp_ms() as i64)
+            .map(|d| d.to_rfc3339()),
+    })
 }
 
 fn card_kind(card: &CardIndicator<Gram<String>, String>) -> &'static str {
@@ -387,6 +520,20 @@ pub struct GetSentencesParams {
     count: Option<usize>,
 }
 
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct SearchParams {
+    /// What to look up: a word or phrase in the language being learned, or a
+    /// native-language meaning. Accent-insensitive.
+    query: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+pub struct FetchParams {
+    /// A result id exactly as returned by the search tool, e.g.
+    /// "french-to-english:42".
+    id: String,
+}
+
 /// Where a tool call's deck state comes from.
 #[derive(Clone)]
 enum StateSource {
@@ -440,7 +587,13 @@ impl YapMcp {
 #[tool_router]
 impl YapMcp {
     #[tool(
-        description = "Search the yap dictionary for words and phrases. Each match includes its language and gram — the token sequence (word + lemma + part of speech) that uniquely identifies it. Other tools take these verbatim; search first rather than constructing grams by hand."
+        title = "Search the dictionary",
+        description = "Search the yap dictionary for words and phrases. Each match includes its language and gram — the token sequence (word + lemma + part of speech) that uniquely identifies it. Other tools take these verbatim; search first rather than constructing grams by hand.",
+        annotations(
+            title = "Search the dictionary",
+            read_only_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn search_dictionary(
         &self,
@@ -494,7 +647,15 @@ impl YapMcp {
     }
 
     #[tool(
-        description = "Add words/phrases to the user's yap deck as new flashcards. Takes (language, gram) pairs, normally obtained from search_dictionary; anything that doesn't name a real dictionary entry is rejected. Confirm with the user before adding."
+        title = "Add flashcards",
+        description = "Add words/phrases to the user's yap deck as new flashcards. Takes (language, gram) pairs, normally obtained from search_dictionary; anything that doesn't name a real dictionary entry is rejected. Confirm with the user before adding.",
+        annotations(
+            title = "Add flashcards",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn add_cards(
         &self,
@@ -571,7 +732,13 @@ impl YapMcp {
     }
 
     #[tool(
-        description = "List the user's currently-due yap flashcards, most overdue first. Each entry carries its language and card object; pass both verbatim to log_review after quizzing the user. Gram cards can be quizzed with example sentences from get_sentences."
+        title = "List due flashcards",
+        description = "List the user's currently-due yap flashcards, most overdue first. Each entry carries its language and card object; pass both verbatim to log_review after quizzing the user. Gram cards can be quizzed with example sentences from get_sentences.",
+        annotations(
+            title = "List due flashcards",
+            read_only_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn get_due_cards(
         &self,
@@ -592,35 +759,97 @@ impl YapMcp {
         let deck = state.deck();
         let due = deck.due_card_summaries(now_ms);
         let total_due = due.len();
+        let locked = deck.locked_count();
 
         let cards: Vec<serde_json::Value> = due
             .iter()
             .take(limit)
-            .map(|summary| {
-                let indicator = summary.card_indicator();
-                json!({
-                    "language": language,
-                    "card": serde_json::to_value(&indicator).expect("card serializes"),
-                    "text": summary.card_text(),
-                    "subtitle": summary.card_subtitle(),
-                    "kind": card_kind(&indicator),
-                    "fsrs_state": summary.state(),
-                    "due": chrono::DateTime::from_timestamp_millis(summary.due_timestamp_ms() as i64)
-                        .map(|d| d.to_rfc3339()),
-                })
-            })
+            .map(|summary| card_summary_json(&language, summary))
             .collect();
 
-        ok_json(json!({
+        let mut response = json!({
             "total_due": total_due,
             "showing": cards.len(),
             "cards": cards,
+            "cards_in_lockup": locked,
             "note": "kind 'written' = recognize the written word; 'listening' = normally an audio card (quiz in text as best you can); 'pronunciation' = a letter-sound pattern. A card's gram field can be passed to get_sentences.",
+        });
+        if locked > 0 {
+            response["lockup_note"] = json!(format!(
+                "{locked} cards are set aside in lockup — when a big backlog is due at once, \
+                 yap keeps a manageable handful active and sets the rest aside to be practiced \
+                 later. unlock_cards releases the next batch; reviewing a locked card also \
+                 unlocks it."
+            ));
+        }
+        ok_json(response)
+    }
+
+    #[tool(
+        title = "Unlock cards",
+        description = "Release the next batch of set-aside cards from lockup, putting them back in the due queue. Lockup is how yap keeps sessions manageable: when a big backlog is due at once, it keeps a handful of cards active and sets the rest aside to be practiced later. Reviewing a locked card also unlocks it. Confirm with the user before calling.",
+        annotations(
+            title = "Unlock cards",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn unlock_cards(&self, ctx: RequestContext<RoleServer>) -> CallToolResult {
+        let slot = match self.state_slot(&ctx).await {
+            Ok(slot) => slot,
+            Err(e) => return error(e),
+        };
+        let mut state = slot.lock().await;
+        if let Err(e) = state.refresh().await {
+            log::warn!("refresh failed, using possibly-stale events: {e:#}");
+        }
+        let language = state.target_language_value();
+
+        let (content, unlocked) = {
+            let deck = state.deck();
+            match deck.get_release_offer() {
+                None => {
+                    return ok_json(json!({
+                        "unlocked": [],
+                        "cards_in_lockup": 0,
+                        "note": "no cards are in lockup",
+                    }));
+                }
+                Some(offer) => {
+                    let unlocked: Vec<serde_json::Value> = offer
+                        .release_preview()
+                        .iter()
+                        .map(|summary| card_summary_json(&language, summary))
+                        .collect();
+                    let DeckEvent::Language(event) = offer.unlock_event();
+                    (event.content, unlocked)
+                }
+            }
+        };
+        if let Err(e) = state.append_event(content).await {
+            return error(format!("failed to save: {e:#}"));
+        }
+
+        let remaining = state.deck().locked_count();
+        ok_json(json!({
+            "unlocked": unlocked,
+            "cards_in_lockup": remaining,
+            "note": "these cards are back in the due queue and will show up in get_due_cards.",
         }))
     }
 
     #[tool(
-        description = "Record the result of reviewing one card. This updates real spaced-repetition scheduling on the user's account, so only call it after actually quizzing the user, with an honest rating."
+        title = "Log a review",
+        description = "Record the result of reviewing one card. This updates real spaced-repetition scheduling on the user's account, so only call it after actually quizzing the user, with an honest rating.",
+        annotations(
+            title = "Log a review",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
     )]
     async fn log_review(
         &self,
@@ -683,7 +912,13 @@ impl YapMcp {
     }
 
     #[tool(
-        description = "Get random example sentences (with translations and source attribution) containing a given gram. Returns two lists: comprehensible_sentences, which are otherwise composed only of words the user already knows (great for quizzing), and other_sentences, sampled from everything containing the gram regardless of difficulty."
+        title = "Get example sentences",
+        description = "Get random example sentences (with translations and source attribution) containing a given gram. Returns two lists: comprehensible_sentences, which are otherwise composed only of words the user already knows (great for quizzing), and other_sentences, sampled from everything containing the gram regardless of difficulty.",
+        annotations(
+            title = "Get example sentences",
+            read_only_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn get_sentences(
         &self,
@@ -708,65 +943,25 @@ impl YapMcp {
         };
         let display = gram.to_display_string(state.context.course.target_language);
 
-        let comprehensible_pool = {
-            let deck = state.deck();
-            let comprehensible = deck.comprehensible_written_grams(false);
-            deck.context()
-                .language_pack
-                .comprehensible_sentences(Some(&interned), |g| comprehensible.contains(g))
-        };
-
-        use rand::seq::IndexedRandom as _;
-        let chosen_comprehensible: Vec<Spur> = comprehensible_pool
-            .choose_multiple(&mut rand::rng(), count)
-            .copied()
-            .collect();
-
-        let pack = state.pack();
-        let all_containing = pack
-            .sentences_containing_gram_index
-            .get(&interned)
-            .cloned()
-            .unwrap_or_default();
-        let other_pool: Vec<Spur> = all_containing
-            .iter()
-            .copied()
-            .filter(|sentence| !chosen_comprehensible.contains(sentence))
-            .collect();
-        let chosen_other: Vec<Spur> = other_pool
-            .choose_multiple(&mut rand::rng(), count)
-            .copied()
-            .collect();
-
-        let render = |sentence: &Spur| {
-            let text = pack.string_rodeo.resolve(sentence);
-            let translations: Vec<&str> = pack
-                .translations
-                .get(sentence)
-                .map(|ts| ts.iter().map(|t| pack.string_rodeo.resolve(t)).collect())
-                .unwrap_or_default();
-            json!({
-                "text": text,
-                "translations": translations,
-                "sources": state.sentence_sources(sentence),
-            })
-        };
-        let comprehensible_sentences: Vec<serde_json::Value> =
-            chosen_comprehensible.iter().map(render).collect();
-        let other_sentences: Vec<serde_json::Value> = chosen_other.iter().map(render).collect();
-
+        let sampled = state.sample_sentences(interned, count);
         ok_json(json!({
             "word": display,
-            "comprehensible_sentences": comprehensible_sentences,
-            "total_comprehensible": comprehensible_pool.len(),
-            "other_sentences": other_sentences,
-            "total_containing_word": all_containing.len(),
+            "comprehensible_sentences": sampled.comprehensible,
+            "total_comprehensible": sampled.total_comprehensible,
+            "other_sentences": sampled.other,
+            "total_containing_word": sampled.total_containing,
             "note": "comprehensible_sentences use only words the user already knows; other_sentences are sampled from everything containing the word and may include unknown words (and may lack translations).",
         }))
     }
 
     #[tool(
-        description = "Get the user's yap stats: streak, XP, review counts, deck size, due cards, comprehension tier, and recent daily activity."
+        title = "Get learning stats",
+        description = "Get the user's yap stats: streak, XP, review counts, deck size, due cards, comprehension tier, and recent daily activity.",
+        annotations(
+            title = "Get learning stats",
+            read_only_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn get_stats(&self, ctx: RequestContext<RoleServer>) -> CallToolResult {
         let slot = match self.state_slot(&ctx).await {
@@ -821,6 +1016,200 @@ impl YapMcp {
             "recent_days": past_days,
         }))
     }
+
+    #[tool(
+        title = "Search dictionary pages",
+        description = "Search the dictionary of the user's yap course. Returns matching entry pages as results with id, title, and url (a citable yap.town dictionary link); pass an id to fetch for the full entry. For deck operations that need exact grams (add_cards, get_sentences, log_review), use search_dictionary instead.",
+        annotations(
+            title = "Search dictionary pages",
+            read_only_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn search(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(params): Parameters<SearchParams>,
+    ) -> CallToolResult {
+        let query = params.query.trim().to_string();
+        if query.is_empty() {
+            return error("query must not be empty");
+        }
+        let slot = match self.state_slot(&ctx).await {
+            Ok(slot) => slot,
+            Err(e) => return error(e),
+        };
+        let mut state = slot.lock().await;
+        if let Err(e) = state.refresh().await {
+            log::warn!("refresh failed, using possibly-stale events: {e:#}");
+        }
+        let course = state.context.course;
+        let results: Vec<serde_json::Value> = state
+            .deck()
+            .get_gram_dictionary_entries(Some(query), 10)
+            .iter()
+            .map(|entry| {
+                json!({
+                    "id": entry_id(&course, entry),
+                    "title": entry_title(entry),
+                    "url": entry_url(&course, &entry.display_text()),
+                })
+            })
+            .collect();
+        ok_json_structured(json!({ "results": results }))
+    }
+
+    #[tool(
+        title = "Fetch a dictionary page",
+        description = "Fetch a dictionary entry page by an id returned from the search tool: definitions, frequency rank, whether it's in the user's deck, and example sentences with translations and source attribution. Returns readable text plus a citable url.",
+        annotations(
+            title = "Fetch a dictionary page",
+            read_only_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn fetch(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        Parameters(params): Parameters<FetchParams>,
+    ) -> CallToolResult {
+        let parsed = params
+            .id
+            .rsplit_once(':')
+            .and_then(|(slug, idx)| Some((slug.to_string(), idx.parse::<usize>().ok()?)));
+        let Some((course_slug, index)) = parsed else {
+            return error(
+                "invalid id — pass an id exactly as returned by the search tool, e.g. \"french-to-english:42\"",
+            );
+        };
+
+        let slot = match self.state_slot(&ctx).await {
+            Ok(slot) => slot,
+            Err(e) => return error(e),
+        };
+        let mut state = slot.lock().await;
+        if let Err(e) = state.refresh().await {
+            log::warn!("refresh failed, using possibly-stale events: {e:#}");
+        }
+        let course = state.context.course;
+        if course_slug != course.dictionary_slug() {
+            return error(format!(
+                "that id belongs to the '{course_slug}' dictionary, but this account's course is '{}'",
+                course.dictionary_slug()
+            ));
+        }
+        let Some(entry) = state.deck().gram_dictionary_entry(index) else {
+            return error(
+                "no dictionary entry with that id — use an id returned by the search tool",
+            );
+        };
+
+        let interned: SpurGram = *state
+            .pack()
+            .gram_frequencies
+            .entries
+            .get_index(index)
+            .expect("index valid: entry was just built from it")
+            .0;
+        let gram_value =
+            serde_json::to_value(state.pack().resolve_gram(&interned)).expect("gram serializes");
+        let language = state.target_language_value();
+        let sampled = state.sample_sentences(interned, 3);
+
+        let display = entry.display_text();
+        let url = entry_url(&course, &display);
+        use std::fmt::Write as _;
+        let mut text = String::new();
+        let _ = writeln!(text, "{display}");
+        match entry.definition() {
+            GramDictionaryDefinition::Dictionary { definitions } => {
+                for def in &definitions {
+                    let _ = write!(text, "• {}", def.native);
+                    if let Some(note) = &def.note {
+                        let _ = write!(text, " ({note})");
+                    }
+                    let _ = writeln!(text);
+                    if !def.example_sentence_target_language.is_empty() {
+                        let _ = writeln!(
+                            text,
+                            "  e.g. “{}” — “{}”",
+                            def.example_sentence_target_language,
+                            def.example_sentence_native_language
+                        );
+                    }
+                }
+            }
+            GramDictionaryDefinition::Phrasebook {
+                meaning,
+                target_language_example,
+                native_language_example,
+            } => {
+                let _ = writeln!(text, "• {meaning}");
+                if let (Some(t), Some(n)) = (target_language_example, native_language_example) {
+                    let _ = writeln!(text, "  e.g. “{t}” — “{n}”");
+                }
+            }
+        }
+        let _ = writeln!(
+            text,
+            "\nFrequency rank {} (1 = most common in this course). {}",
+            entry.frequency_index() + 1,
+            if entry.is_in_deck() {
+                "Already in the user's deck."
+            } else {
+                "Not in the user's deck."
+            }
+        );
+        for (label, list) in [
+            (
+                "Example sentences the user can already fully understand:",
+                &sampled.comprehensible,
+            ),
+            (
+                "More sentences containing it (may use words the user hasn't learned):",
+                &sampled.other,
+            ),
+        ] {
+            if list.is_empty() {
+                continue;
+            }
+            let _ = writeln!(text, "\n{label}");
+            for sentence in list {
+                let _ = write!(
+                    text,
+                    "• “{}”",
+                    sentence["text"].as_str().unwrap_or_default()
+                );
+                if let Some(translation) = sentence["translations"].get(0).and_then(|t| t.as_str())
+                {
+                    let _ = write!(text, " — “{translation}”");
+                }
+                let sources: Vec<&str> = sentence["sources"]
+                    .as_array()
+                    .map(|a| a.iter().filter_map(|s| s.as_str()).collect())
+                    .unwrap_or_default();
+                if !sources.is_empty() {
+                    let _ = write!(text, " (source: {})", sources.join(", "));
+                }
+                let _ = writeln!(text);
+            }
+        }
+        let _ = writeln!(text, "\nDictionary page: {url}");
+
+        ok_json_structured(json!({
+            "id": params.id,
+            "title": entry_title(&entry),
+            "text": text,
+            "url": url,
+            "metadata": {
+                "language": language,
+                "gram": gram_value,
+                "frequency_rank": entry.frequency_index() + 1,
+                "in_deck": entry.is_in_deck(),
+                "is_phrase": entry.is_phrase(),
+            },
+        }))
+    }
 }
 
 #[tool_handler]
@@ -841,7 +1230,11 @@ impl ServerHandler for YapMcp {
              get_due_cards. Pass those objects back verbatim; the server rejects anything \
              that doesn't name a real dictionary entry. To add new words: search_dictionary \
              first, show the user what you found, then pass the matches' language + gram to \
-             add_cards."
+             add_cards.\n\
+             \n\
+             search and fetch are a standard browse/cite pair over the public dictionary at \
+             yap.town/d/ — use them to look up and cite entries; use search_dictionary when \
+             you need exact grams for the deck tools."
                 .to_string(),
         );
         info


### PR DESCRIPTION
Gets the MCP connector ready for the Anthropic connectors directory and ChatGPT (connector + future app):

**MCP server**
- Annotations (`title`, `readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint`) on every tool — the top directory-rejection cause
- `search`/`fetch` pair in OpenAI's required schema with `structuredContent`, returning citable URLs into the public dictionary; slug construction shared with `generate-dictionary-data` via `language-utils` (live sample: 39/39 URLs hit, incl. accents/apostrophes/œ)
- `unlock_cards`: releases the next lockup batch via the deck's own release offer (same semantics as the app's "Review N more cards"); `get_due_cards` now reports `cards_in_lockup` + an explanation when nonzero
- Hardening: per-IP rate limits (fixed 60s windows) on `/oauth/{register,authorize,approve,token}`; per-user deck state evicted after 6h idle

**yap.town**
- New pages: `/privacy`, `/terms`, `/mcp` (connector docs, troubleshooting, support + security contacts) + footer links — required by both directories
- "André" accented everywhere the name appears (incl. static site)

**Meta**
- `smoke/seed_test_user.py` populates the reviewer test account (15 cards, mixed-rating history); setup script can set a stable password
- README: unlock/search/fetch docs, reviewer-account section, asymmetric-keys migration checklist
- CLAUDE.md: privacy-policy upkeep rule; dictionary pipeline says Cloudflare (not Vercel)

**Verified**: clippy/fmt/tests clean, wasm + tsc build, stdio + remote OAuth smokes ALL PASS, lockup release path covered by `test_lockup_locks_due_complement_and_release_restores`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMv3jpoiNzt3rg6sKehb7e