### PR TITLE
CI: parallelize the deploy pipeline and fix the frozen caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,60 +14,54 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
+
+      # Only the rkyv packs are needed to build (ai-backend include_bytes!s
+      # them); pulling all of LFS is several GB slower.
+      - name: Pull LFS rkyv files
+        run: git lfs pull --include="out/*_for_*/language_data.rkyv"
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: "1.96.0"
-          override: true
+          targets: wasm32-unknown-unknown
           components: rustfmt, clippy
-          target: wasm32-unknown-unknown
 
-      - name: Cache cargo registry
+      # Keyed on Cargo.lock so the cache is re-saved whenever dependencies
+      # change. (A constant key is a trap: actions/cache never re-saves on a
+      # primary-key hit, so the cache silently freezes at its first save and
+      # every later run recompiles everything newer than it.)
+      - name: Cache cargo
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-ci
+          key: ${{ runner.os }}-cargo-ci-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-ci-
             ${{ runner.os }}-cargo-
 
+      - uses: taiki-e/install-action@nextest
+
       - name: Rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace -- -D warnings
+        run: cargo clippy --workspace -- -D warnings
 
       - name: Clippy (WASM)
         run: cargo clippy --target wasm32-unknown-unknown -- -D warnings
         working-directory: yap-frontend-rs
 
-      - uses: taiki-e/install-action@nextest
-
       - name: Tests (default features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --all
+        run: cargo nextest run --all
 
       - name: Tests (no default features)
-        uses: actions-rs/cargo@v1
-        with:
-          command: nextest
-          args: run --all --no-default-features
+        run: cargo nextest run --all --no-default-features
 
   # Verify the custom espeak-ng fork (anchpop/espeak-ng) still builds and can
   # phonemize — the transcription grader shells out to it at runtime. Only the

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Structure: checks + the three build jobs run in parallel; the deploy jobs
+# gate on ALL of them, so nothing deploys unless every check passes and every
+# artifact builds. (Pushing a :sha image to the Fly registry for a commit that
+# then fails tests is harmless — the image is only deployed by the gated jobs.)
 jobs:
-  deploy:
+  # ===== TEST PHASE =====
+  checks:
     runs-on: big-runner
     steps:
       - name: Checkout
@@ -31,53 +36,24 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rustfmt, clippy
 
+      # Keyed on Cargo.lock so the cache is re-saved whenever dependencies
+      # change. (A constant key is a trap: actions/cache never re-saves on a
+      # primary-key hit, so the cache silently freezes at its first save and
+      # every later run recompiles everything newer than it.)
       - name: Cache cargo
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-deploy
+          key: ${{ runner.os }}-cargo-checks-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-deploy-
+            ${{ runner.os }}-cargo-checks-
             ${{ runner.os }}-cargo-
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
       - uses: taiki-e/install-action@nextest
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Setup Fly CLI
-        uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Auth to Fly registry
-        run: flyctl auth docker
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_SECRET }}
-
-      # ===== TEST PHASE =====
-      # Any failure here aborts the whole pipeline before anything is built or deployed.
 
       - name: Rustfmt
         run: cargo fmt --all -- --check
@@ -95,8 +71,51 @@ jobs:
       - name: Tests (no default features)
         run: cargo nextest run --all --no-default-features
 
-      # ===== BUILD PHASE =====
-      # Everything that can fail builds here. Deploys only start once all of these pass.
+  # ===== BUILD PHASE =====
+  web-build:
+    runs-on: big-runner
+    outputs:
+      dictionary_changed: ${{ steps.dictionary-digest.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: Pull LFS rkyv files
+        run: git lfs pull --include="out/*_for_*/language_data.rkyv"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.96.0"
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-web-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-web-
+            ${{ runner.os }}-cargo-
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Build WASM module
         run: wasm-pack build --release
@@ -136,6 +155,59 @@ jobs:
             routes.include = ['/d/*', '/blog/*', '/sitemap*', '/robots.txt'];
             fs.writeFileSync('$DEPLOY_DIR/_routes.json', JSON.stringify(routes, null, 2));
           "
+          tar -cf deploy-output.tar deploy-output
+
+      - name: Upload deploy directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-output
+          path: deploy-output.tar
+          retention-days: 3
+
+      # Compare a content digest of the generated dictionary data against the
+      # digest stored in KV. If they match, the ~200k-key KV re-upload (and the
+      # artifact shuffling for it) is skipped entirely. This is an exact
+      # comparison of the generated output, not a path-based heuristic.
+      - name: Check whether dictionary data changed since last KV upload
+        id: dictionary-digest
+        run: node scripts/upload-dictionary-to-kv.js --check
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Pack dictionary data
+        if: steps.dictionary-digest.outputs.changed == 'true'
+        run: tar -cf dictionary-data.tar static-site/src/data static-site/public/search
+
+      - name: Upload dictionary data
+        if: steps.dictionary-digest.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dictionary-data
+          path: dictionary-data.tar
+          retention-days: 3
+
+  backend-image:
+    runs-on: big-runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: Pull LFS rkyv files
+        run: git lfs pull --include="out/*_for_*/language_data.rkyv"
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Auth to Fly registry
+        run: flyctl auth docker
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_SECRET }}
 
       - name: Build and push Fly image
         uses: docker/build-push-action@v5
@@ -147,51 +219,40 @@ jobs:
           cache-from: type=registry,ref=registry.fly.io/yap-ai-backend:cache
           cache-to: type=registry,ref=registry.fly.io/yap-ai-backend:cache,mode=max
 
-      - name: Install Modal
-        run: pip install modal
+  mcp-image:
+    runs-on: big-runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: false
 
-      # ===== DEPLOY PHASE =====
-      # Sequential: Fly first (safest to go early), then Cloudflare Pages, then Modal.
-      # Dictionary KV upload runs last since it's the least critical.
+      - name: Pull LFS rkyv files
+        run: git lfs pull --include="out/*_for_*/language_data.rkyv"
 
-      - name: Deploy to Fly.io
-        run: flyctl deploy --image registry.fly.io/yap-ai-backend:${{ github.sha }}
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Auth to Fly registry
+        run: flyctl auth docker
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_SECRET }}
 
-      # Probe the machine that's actually serving traffic. This catches
-      # runtime-only breakage that compiles and passes unit tests: missing
-      # crypto providers, glibc mismatches, missing env vars, expired API keys.
-      # (Also runnable locally: ./scripts/smoke_test_server.sh [base-url])
-      - name: Smoke test deployed backend
-        run: ./scripts/smoke_test_server.sh
-
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: deploy-output
-          command: pages deploy . --project-name=yap
-
-      - name: Deploy Modal apps
-        run: modal deploy modal-envs/wav2vec2_phoneme.py
-        env:
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-
-      - name: Upload dictionary data to KV
-        run: node scripts/upload-dictionary-to-kv.js
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      # ===== MCP SERVER =====
-      # Deployed last: a failure here must never block the frontend/backend
-      # deploys above. One-time setup before the first run:
-      #   flyctl apps create yap-mcp
-      #   flyctl secrets set --app yap-mcp SUPABASE_JWT_SECRET=...
-
+      # Built outside Docker (the Dockerfile COPYs dist/index.html in);
+      # nothing generated is committed.
       - name: Build MCP review widget
         run: |
           pnpm install --dir yap-mcp/widget
@@ -206,6 +267,101 @@ jobs:
           tags: registry.fly.io/yap-mcp:${{ github.sha }}
           cache-from: type=registry,ref=registry.fly.io/yap-mcp:cache
           cache-to: type=registry,ref=registry.fly.io/yap-mcp:cache,mode=max
+
+  # ===== DEPLOY PHASE =====
+  # Sequential within the job: Fly first (safest to go early), then Cloudflare
+  # Pages, then Modal. Dictionary KV upload runs last since it's the least
+  # critical.
+  deploy:
+    runs-on: big-runner
+    needs: [checks, web-build, backend-image, mcp-image]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --image registry.fly.io/yap-ai-backend:${{ github.sha }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_SECRET }}
+
+      # Probe the machine that's actually serving traffic. This catches
+      # runtime-only breakage that compiles and passes unit tests: missing
+      # crypto providers, glibc mismatches, missing env vars, expired API keys.
+      # (Also runnable locally: ./scripts/smoke_test_server.sh [base-url])
+      - name: Smoke test deployed backend
+        run: ./scripts/smoke_test_server.sh
+
+      - name: Download deploy directory
+        uses: actions/download-artifact@v4
+        with:
+          name: deploy-output
+
+      - name: Unpack deploy directory
+        run: tar -xf deploy-output.tar
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: deploy-output
+          command: pages deploy . --project-name=yap
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Deploy Modal apps
+        run: modal deploy modal-envs/wav2vec2_phoneme.py
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+
+      - name: Download dictionary data
+        if: needs.web-build.outputs.dictionary_changed == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: dictionary-data
+
+      - name: Upload dictionary data to KV
+        if: needs.web-build.outputs.dictionary_changed == 'true'
+        run: |
+          tar -xf dictionary-data.tar
+          node scripts/upload-dictionary-to-kv.js
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  # ===== MCP SERVER =====
+  # A separate deploy job so a failure here never blocks the frontend/backend
+  # deploys above. One-time setup before the first run:
+  #   flyctl apps create yap-mcp
+  #   flyctl secrets set --app yap-mcp SUPABASE_JWT_SECRET=...
+  deploy-mcp:
+    runs-on: big-runner
+    needs: [checks, web-build, backend-image, mcp-image]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy MCP server to Fly.io
         run: flyctl deploy --config yap-mcp/fly.toml --ha=false --image registry.fly.io/yap-mcp:${{ github.sha }}

--- a/scripts/upload-dictionary-to-kv.js
+++ b/scripts/upload-dictionary-to-kv.js
@@ -5,10 +5,14 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 
 const DATA_DIR = 'static-site/src/data';
 const SEARCH_DIR = 'static-site/public/search';
 const KV_NAMESPACE_ID = '4f0627a5baf348e19fd656fc0a3896cd';
+// Digest of all source files, stored in KV after a successful upload so the
+// next run can skip re-uploading identical data (see --check below).
+const DIGEST_KEY = 'meta:dictionary-digest';
 const BATCH_SIZE = 5000; // Max 10000 per CF API call, but stay conservative on payload size
 const MAX_RETRIES = 3;
 const CONCURRENCY = 10; // Number of parallel API requests
@@ -22,6 +26,61 @@ if (!API_TOKEN || !ACCOUNT_ID) {
 }
 
 const KV_BULK_URL = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${KV_NAMESPACE_ID}/bulk`;
+const KV_VALUE_URL = (key) => `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/storage/kv/namespaces/${KV_NAMESPACE_ID}/values/${encodeURIComponent(key)}`;
+
+// Hash every file that main() would upload (path + content, in sorted order).
+// If the generator output is byte-identical to what's already in KV, the
+// upload can be skipped.
+function computeDigest() {
+  const hash = crypto.createHash('sha256');
+  const walk = (dir) => {
+    if (!fs.existsSync(dir)) return;
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+      .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    for (const entry of entries) {
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(p);
+      } else {
+        hash.update(p);
+        hash.update('\0');
+        hash.update(fs.readFileSync(p));
+        hash.update('\0');
+      }
+    }
+  };
+  walk(DATA_DIR);
+  walk(SEARCH_DIR);
+  return hash.digest('hex');
+}
+
+async function fetchRemoteDigest() {
+  const res = await fetch(KV_VALUE_URL(DIGEST_KEY), {
+    headers: { 'Authorization': `Bearer ${API_TOKEN}` },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to read ${DIGEST_KEY}: ${res.status} ${await res.text()}`);
+  return await res.text();
+}
+
+// --check: compare the local digest against KV without uploading anything.
+// Writes changed=<bool> to $GITHUB_OUTPUT when running in Actions. Fails open:
+// if the KV read errors, report "changed" so the deploy falls back to a full
+// upload rather than being blocked.
+async function check() {
+  const digest = computeDigest();
+  let remote = null;
+  try {
+    remote = await fetchRemoteDigest();
+  } catch (err) {
+    console.warn(`Could not read ${DIGEST_KEY} (${err.message}); assuming upload is needed`);
+  }
+  const changed = remote !== digest;
+  console.log(`Local digest ${digest}, KV digest ${remote ?? '(none)'} — ${changed ? 'upload needed' : 'data unchanged, upload can be skipped'}`);
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `changed=${changed}\n`);
+  }
+}
 
 async function kvBulkPut(pairs, attempt = 1) {
   const res = await fetch(KV_BULK_URL, {
@@ -94,6 +153,10 @@ async function flushPending() {
 }
 
 async function main() {
+  // Digest before uploading so the stored value describes exactly the files
+  // this run pushed.
+  const digest = computeDigest();
+
   // Upload courses manifest
   console.log('Collecting courses manifest...');
   await addPairFromFile('courses', path.join(DATA_DIR, 'courses.json'));
@@ -155,10 +218,14 @@ async function main() {
 
   // Final flush for any remaining pairs
   await flushPending();
-  console.log(`Done! ${totalUploaded} keys uploaded to KV in ${totalBatches} batches.`);
+
+  // Record the digest only after everything uploaded, so a partial failure
+  // leaves the old digest in place and the next run re-uploads everything.
+  await kvBulkPut([{ key: DIGEST_KEY, value: digest }]);
+  console.log(`Done! ${totalUploaded} keys uploaded to KV in ${totalBatches} batches (digest ${digest}).`);
 }
 
-main().catch(err => {
+(process.argv.includes('--check') ? check() : main()).catch(err => {
   console.error(err);
   process.exit(1);
 });

--- a/yap-ai-backend/Dockerfile
+++ b/yap-ai-backend/Dockerfile
@@ -57,14 +57,21 @@ COPY --from=planner /app/Cargo.toml Cargo.toml
 COPY Cargo.lock .
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook --release --recipe-path recipe.json
-# Copy actual source and data
+# out/ before the sources: this layer (rkyv packs included) is huge and rarely
+# changes — keep it above the every-commit source layers so it isn't re-created
+# (and re-exported to the cache registry) on every deploy.
+COPY out out
 COPY yap-ai-backend yap-ai-backend
 COPY language-utils language-utils
 COPY libraries/google-tts libraries/google-tts
 COPY libraries/autograde-core libraries/autograde-core
 COPY libraries/espeak libraries/espeak
-COPY out out
-RUN cargo build --release --bin ai-backend
+# Drop target/ within the same layer: it's ~hundreds of MB of incremental
+# artifacts that change every commit, and mode=max cache export would ship
+# all of it to the registry each deploy.
+RUN cargo build --release --bin ai-backend \
+    && cp target/release/ai-backend /app/ai-backend \
+    && rm -rf target
 
 # Runtime stage with required libraries.
 # NOTE: must be the same distro as the builder stage above (or newer), or the
@@ -91,5 +98,5 @@ ENV ESPEAK_NG_BIN=/usr/local/bin/espeak-ng \
 RUN espeak-ng --version \
     && espeak-ng --path="$ESPEAK_NG_DATA_PATH" -v fr -q --ipa -x "on est" | grep -q .
 
-COPY --from=builder /app/target/release/ai-backend /usr/local/bin
+COPY --from=builder /app/ai-backend /usr/local/bin/ai-backend
 ENTRYPOINT ["/usr/local/bin/ai-backend"]

--- a/yap-mcp/Dockerfile
+++ b/yap-mcp/Dockerfile
@@ -2,10 +2,59 @@
 # Pin the Rust version (keep in sync with rust-toolchain.toml) AND the distro —
 # builder and runtime must be the same distro or the binary hits glibc
 # mismatches at startup (see yap-ai-backend/Dockerfile for the war story).
-FROM rust:1.96-trixie AS builder
+FROM lukemathwalker/cargo-chef:latest-rust-1.96-trixie AS chef
 WORKDIR /app
-COPY . .
-RUN cargo build --release -p yap-mcp
+
+FROM chef AS planner
+COPY Cargo.toml Cargo.lock ./
+COPY yap-mcp/Cargo.toml yap-mcp/Cargo.toml
+COPY yap-frontend-rs/Cargo.toml yap-frontend-rs/Cargo.toml
+COPY language-utils/Cargo.toml language-utils/Cargo.toml
+COPY libraries/weapon/Cargo.toml libraries/weapon/Cargo.toml
+COPY libraries/imdex_map/Cargo.toml libraries/imdex_map/Cargo.toml
+COPY libraries/eyedee/Cargo.toml libraries/eyedee/Cargo.toml
+COPY libraries/autograde-core/Cargo.toml libraries/autograde-core/Cargo.toml
+# Trim the workspace to yap-mcp's path-dependency closure (yap-frontend-rs
+# pulls in weapon, imdex_map, eyedee, and autograde-core).
+RUN sed -i '/^members = \[/,/^\]/c\members = [\n    "yap-mcp",\n    "yap-frontend-rs",\n    "language-utils",\n    "libraries/weapon",\n    "libraries/imdex_map",\n    "libraries/eyedee",\n    "libraries/autograde-core",\n]' Cargo.toml
+# cargo-chef needs stub files for every target declared in the manifests
+RUN mkdir -p yap-mcp/src && echo "fn main() {}" > yap-mcp/src/main.rs
+RUN mkdir -p yap-frontend-rs/src yap-frontend-rs/benches \
+    && touch yap-frontend-rs/src/lib.rs \
+    && echo "fn main() {}" > yap-frontend-rs/benches/simulation.rs \
+    && echo "fn main() {}" > yap-frontend-rs/benches/profile_next_cards.rs
+RUN mkdir -p language-utils/src && touch language-utils/src/lib.rs
+RUN mkdir -p libraries/weapon/src/bin \
+    && touch libraries/weapon/src/lib.rs \
+    && echo "fn main() {}" > libraries/weapon/src/bin/weapon-scope.rs
+RUN mkdir -p libraries/imdex_map/src && touch libraries/imdex_map/src/lib.rs
+RUN mkdir -p libraries/eyedee/src && touch libraries/eyedee/src/lib.rs
+RUN mkdir -p libraries/autograde-core/src && touch libraries/autograde-core/src/lib.rs
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/Cargo.toml Cargo.toml
+COPY Cargo.lock .
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# out/ before the sources: yap-frontend-rs include_str!s the showcase.json and
+# language_data.hash files, and this layer (rkyv packs included) is huge and
+# rarely changes — keep it above the every-commit source layers.
+COPY out out
+COPY yap-mcp yap-mcp
+COPY yap-frontend-rs yap-frontend-rs
+COPY language-utils language-utils
+COPY libraries/weapon libraries/weapon
+COPY libraries/imdex_map libraries/imdex_map
+COPY libraries/eyedee libraries/eyedee
+COPY libraries/autograde-core libraries/autograde-core
+# Drop target/ within the same layer: it's ~hundreds of MB of incremental
+# artifacts that change every commit, and mode=max cache export would ship
+# all of it to the registry each deploy.
+RUN cargo build --release -p yap-mcp \
+    && cp target/release/yap-mcp /app/yap-mcp-bin \
+    && rm -rf target
 
 FROM debian:trixie-slim AS runtime
 WORKDIR /app
@@ -14,7 +63,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /app/target/release/yap-mcp /usr/local/bin/yap-mcp
+COPY --from=builder /app/yap-mcp-bin /usr/local/bin/yap-mcp
 # Language packs are read from disk at runtime (lazily, per course).
 COPY out /app/out
 ENV YAP_OUT_DIR=/app/out


### PR DESCRIPTION
The deploy job ran everything serially and took ~31 min. Measured breakdown of the last successful run: Fly image build 6:33, MCP image build 7:03, KV upload 3:30, tests ~4:00, checkout 1:50, dictionary data 1:28 — all back-to-back in one job.

This takes the "do everything, but make it fast" approach: nothing is path-filtered; every deploy still runs every check and rebuilds every artifact.

## What was wrong

1. **The cargo cache never updated.** The key was the constant `Linux-cargo-deploy`, and actions/cache never re-saves on a primary-key hit (the last run literally logs `Cache hit occurred on the primary key Linux-cargo-deploy, not saving cache`). The cache froze at its first save; every run since recompiled everything newer than it. Same bug in PR CI (`Linux-cargo-ci`).
2. **yap-mcp's image had zero dependency caching** — `COPY . .` + `cargo build --release -p yap-mcp` recompiled the entire dep tree (220s) on every deploy.
3. **Everything was serial** — the two Docker builds alone were 13.5 min back-to-back with no dependency between them.
4. **Docker cache export waste** — the 931MB `COPY out out` layer sat *below* the every-commit source layers in the ai-backend builder, so it was re-created and re-pushed to the Fly cache registry every deploy; the final build layers also exported hundreds of MB of throwaway `target/` incrementals (mode=max).
5. **The KV upload re-pushed ~200k unchanged keys** (3:30) every deploy even when the dictionary data hadn't changed.

## What changed

- **deploy.yml is now a job DAG**: `checks`, `web-build`, `backend-image`, `mcp-image` run in parallel; `deploy` and `deploy-mcp` gate on *all* of them. The "nothing deploys unless everything passes" property is preserved — and slightly strengthened, since a broken MCP image now also blocks the backend/frontend deploy jobs from starting, while an MCP *deploy* failure still can't block them (separate job). Images pushed to the Fly registry for a commit that fails tests are harmless — they're only ever deployed by the gated jobs.
- **Cargo cache keys derive from `Cargo.lock`** with prefix restore-keys, per job flavor (`cargo-checks-`, `cargo-web-`, `cargo-ci-`), falling back to any `cargo-` cache including the old frozen ones.
- **yap-mcp Dockerfile uses cargo-chef** mirroring yap-ai-backend, with the workspace trimmed to yap-mcp's path-dependency closure. Validated locally end-to-end: `cargo metadata` on the replicated planner stage, then a real `cargo chef cook` + release build — only ~20 crates recompile on top of the cooked layer (vs the full tree today), and the produced binary runs.
- **Docker layer hygiene in both images**: `COPY out out` moved above the source layers; the final build layer `cp`s the binary out and drops `target/` in the same `RUN`, so cache export stops shipping incremental artifacts.
- **KV upload skips when data is unchanged**: `upload-dictionary-to-kv.js` stores a sha256 of all uploaded files in KV (`meta:dictionary-digest`, written only after a fully successful upload). `--check` mode compares before deploying and fails open (any read error ⇒ full upload). This is an exact digest of the generated output, not a folder heuristic, so there's no transitive-dependency footgun; if generator output were ever nondeterministic the digest simply never matches and we're back to today's always-upload behavior.
- **PR CI stops pulling all ~4.5GB of LFS** — only the rkyv packs the build embeds are fetched (the same selective pull deploy already used, which proves it's sufficient). Also swapped the archived `actions-rs/*` actions for the `dtolnay/rust-toolchain` + plain-command pattern deploy already uses.

## Expected wall-clock

Longest parallel leg (~7-8 min) + deploy leg (~5 min) ≈ **12–15 min**, vs ~31 min today, with further improvement on deploys where the dictionary data and dependencies haven't changed. First run after merge is partially cold (new cache key flavors, rebuilt Docker cache layers) — judge timings from the second deploy onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Re1FWrQ5ijgh1FXQW7tAAu