### PR TITLE
Widen Sentry filter for transient WASM network errors

### DIFF
--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -24,13 +24,20 @@ Sentry.init({
       return null;
     }
 
-    // Filter WASM fetch failures on iOS/WKWebView. These are transient network
-    // errors during .wasm module initialization — identifiable by "Load failed"
-    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
-    if (message === "Load failed") {
+    // Filter transient network errors during .wasm module initialization. The
+    // WASM module is pulled in via a top-level await in generated wasm-bindgen
+    // glue, so a dropped connection during the fetch/streaming-compile surfaces
+    // as an uncatchable global error rather than a promise our code could
+    // .catch(). These frequently have no stacktrace, since they happen during
+    // module evaluation before any of our code runs.
+    if (message.includes("WebAssembly compilation aborted: Network error")) {
+      return null;
+    }
+    if (message.includes("Load failed")) {
       const frames =
         event.exception?.values?.[0]?.stacktrace?.frames ?? [];
       if (
+        frames.length === 0 ||
         frames.some(
           (f) =>
             f.filename?.includes("wasm-helper") ||


### PR DESCRIPTION
## Summary

Reviewed recent production Sentry issues for the `javascript-react` project. Most unresolved issues are either already caught-and-reported (`handled:yes`) network blips, or came from a single session on an ancient/unsupported browser (Chrome 75 / Android 6, from third-party `beacon.min.js`) — not something worth code changes.

Two issues were genuinely unhandled (`handled:no`, `auto.browser.global_handlers.*`) across multiple distinct users/devices:
- `CompileError`/`TypeError: WebAssembly compilation aborted: Network error: Response body loading was aborted`
- `TypeError: TypeError: Load failed`

Both originate from the WASM module load, which happens via a top-level `await` inside generated wasm-bindgen glue that's statically imported at the top of the module graph — this can't be wrapped in `try/catch` at any call site in our code, since the rejection happens during module evaluation, before any of our code runs.

The codebase already has an established precedent for this exact class of issue: a `beforeSend` filter in `instrument.ts` for transient WASM network errors (added for a prior, related fix). It had two gaps:
- It used an exact `message === "Load failed"` match, but Sentry actually reports the value as the double-prefixed `"TypeError: Load failed"`, so the filter never matched.
- It required stack frames pointing at the WASM file, but these top-level-await failures frequently report with **no stacktrace at all** (module evaluation hasn't produced any of our frames yet), so the filter would still miss them even with the message fixed.
- There was no filter at all yet for the `WebAssembly compilation aborted: Network error` message.

This PR widens the message match to `.includes()`, allows filtering when no stack frames are present, and adds a filter for the WASM-compilation-abort message — extending the existing convention rather than changing how the app loads WASM.

## Test plan

- [x] Reviewed the diff carefully; change is a small, self-contained edit to existing conditional logic with no new imports/types.
- [ ] Not able to run `pnpm tsc -b`/`eslint` in this sandbox since it requires a `wasm-pack` build of `yap-frontend-rs/pkg` that isn't available here — the change touches no WASM-related code paths, only a `beforeSend` string/array check in `instrument.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XK7EUEaYvETcJg1Q2QAKxW)_