### PR TITLE
yap-mcp: stateless streamable HTTP + content-addressed widget URI

### DIFF
--- a/yap-mcp/smoke/remote_oauth.py
+++ b/yap-mcp/smoke/remote_oauth.py
@@ -284,8 +284,10 @@ status, headers, body = req("POST", f"{BASE}/mcp", headers=mcp_headers, body={
 init = sse_json(body)
 session_id = headers.get("mcp-session-id")
 check("mcp initialize", status == 200 and "serverInfo" in init.get("result", {}), body[:200])
-check("session id issued", bool(session_id), str(session_id))
-mcp_headers["Mcp-Session-Id"] = session_id
+# Stateless streamable HTTP: the server issues no session id, so a deploy
+# that replaces the machine can't strand a client on a stale session. Every
+# request stands alone on its bearer token; there's no Mcp-Session-Id to echo.
+check("no session id issued (stateless)", not session_id, str(session_id))
 
 status, _, body = req("POST", f"{BASE}/mcp", headers=mcp_headers,
                       body={"jsonrpc": "2.0", "method": "notifications/initialized"})

--- a/yap-mcp/src/remote.rs
+++ b/yap-mcp/src/remote.rs
@@ -179,8 +179,8 @@ pub struct RemoteApp {
     /// Encrypts the Supabase session embedded in the tokens we mint, so the
     /// OAuth client never holds a raw Supabase credential.
     token_cipher: ChaCha20Poly1305,
-    /// The built review widget HTML (None when not built).
-    pub widget: Option<Arc<String>>,
+    /// The built review widget (None when not built).
+    pub widget: Option<Arc<crate::server::Widget>>,
     users: Mutex<HashMap<String, UserSlot>>,
     codes: Mutex<HashMap<String, PendingCode>>,
     pending_auth: Mutex<HashMap<String, PendingAuth>>,
@@ -314,6 +314,15 @@ pub async fn serve(app: Arc<RemoteApp>) -> anyhow::Result<()> {
             {
                 let mut config = StreamableHttpServerConfig::default();
                 config.allowed_hosts = allowed_hosts(&app.config);
+                // Stateless: no server-side session state, so a deploy that
+                // replaces the machine can't strand a client on a session id
+                // the new process never issued (the old failure surfaced by
+                // the Anthropic proxy as an opaque "Invalid content from
+                // server"). Auth is a per-request bearer anyway, so every
+                // request is already self-contained. `json_response` returns
+                // plain application/json instead of SSE framing.
+                config.stateful_mode = false;
+                config.json_response = true;
                 config
             },
         );

--- a/yap-mcp/src/server.rs
+++ b/yap-mcp/src/server.rs
@@ -649,14 +649,33 @@ enum StateSource {
     PerUser(Arc<crate::remote::RemoteApp>),
 }
 
-/// URI of the review widget, the interactive card UI hosts render inline
-/// (MCP Apps extension). Served from resources/read.
-pub const WIDGET_URI: &str = "ui://yap/review.html";
+/// Base URI of the review widget, the interactive card UI hosts render
+/// inline (MCP Apps extension). The URI hosts serve carries a content hash
+/// suffix ([`Widget::uri`]) so a rebuilt widget gets a fresh URI — hosts
+/// (claude.ai) cache `ui://` resources by URI and would otherwise keep
+/// serving a stale iframe after every widget change.
+pub const WIDGET_URI_BASE: &str = "ui://yap/review.html";
 const WIDGET_MIME: &str = "text/html;profile=mcp-app";
+
+/// The built review widget together with its content-addressed URI.
+pub struct Widget {
+    pub html: String,
+    /// `ui://yap/review.html@<12 hex of sha256(html)>`.
+    pub uri: String,
+}
+
+/// Content-addressed URI for a widget build: base + first 12 hex of the
+/// HTML's sha256. Distinct HTML ⇒ distinct URI ⇒ hosts refetch it.
+fn versioned_widget_uri(html: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(html.as_bytes());
+    let hex: String = digest.iter().take(6).map(|b| format!("{b:02x}")).collect();
+    format!("{WIDGET_URI_BASE}@{hex}")
+}
 
 /// Load the built review widget. Absent (not built) is fine: widget tools
 /// degrade to text and the resource simply isn't listed.
-pub fn load_widget_html() -> Option<Arc<String>> {
+pub fn load_widget_html() -> Option<Arc<Widget>> {
     let path = std::env::var("YAP_WIDGET_HTML")
         .map(PathBuf::from)
         .unwrap_or_else(|_| {
@@ -667,12 +686,13 @@ pub fn load_widget_html() -> Option<Arc<String>> {
         });
     match std::fs::read_to_string(&path) {
         Ok(html) => {
+            let uri = versioned_widget_uri(&html);
             log::info!(
-                "review widget loaded from {} ({} bytes)",
+                "review widget loaded from {} ({} bytes) as {uri}",
                 path.display(),
                 html.len()
             );
-            Some(Arc::new(html))
+            Some(Arc::new(Widget { html, uri }))
         }
         Err(e) => {
             log::warn!(
@@ -710,11 +730,11 @@ fn widget_resource_meta() -> rmcp::model::Meta {
 /// Per-tool `_meta` when the widget is available: template linkage for
 /// present_card, widget-only visibility for get_audio, and widget
 /// callability for the tools the iframe invokes.
-fn widget_tool_meta(tool_name: &str) -> Option<rmcp::model::Meta> {
+fn widget_tool_meta(tool_name: &str, widget_uri: &str) -> Option<rmcp::model::Meta> {
     match tool_name {
         "present_card" => Some(meta_from(json!({
-            "ui": { "resourceUri": WIDGET_URI },
-            "openai/outputTemplate": WIDGET_URI,
+            "ui": { "resourceUri": widget_uri },
+            "openai/outputTemplate": widget_uri,
             "openai/toolInvocation/invoking": "Dealing a card…",
             "openai/toolInvocation/invoked": "Card ready",
         }))),
@@ -732,11 +752,11 @@ fn widget_tool_meta(tool_name: &str) -> Option<rmcp::model::Meta> {
 #[derive(Clone)]
 pub struct YapMcp {
     source: StateSource,
-    widget: Option<Arc<String>>,
+    widget: Option<Arc<Widget>>,
 }
 
 impl YapMcp {
-    pub fn new(state: YapState, widget: Option<Arc<String>>) -> Self {
+    pub fn new(state: YapState, widget: Option<Arc<Widget>>) -> Self {
         Self {
             source: StateSource::Single(Arc::new(tokio::sync::Mutex::new(state))),
             widget,
@@ -1641,9 +1661,9 @@ impl ServerHandler for YapMcp {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         let mut tools = Self::tool_router().list_all();
-        if self.widget.is_some() {
+        if let Some(widget) = &self.widget {
             for tool in &mut tools {
-                if let Some(meta) = widget_tool_meta(&tool.name) {
+                if let Some(meta) = widget_tool_meta(&tool.name, &widget.uri) {
                     tool.meta = Some(meta);
                 }
             }
@@ -1660,13 +1680,13 @@ impl ServerHandler for YapMcp {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, McpError> {
         let mut result = ListResourcesResult::default();
-        if let Some(html) = &self.widget {
-            let mut resource = Resource::new(WIDGET_URI, "yap review card");
+        if let Some(widget) = &self.widget {
+            let mut resource = Resource::new(widget.uri.clone(), "yap review card");
             resource.title = Some("yap review card".to_string());
             resource.description =
                 Some("Interactive flashcard widget: audio, reveal, and grading.".to_string());
             resource.mime_type = Some(WIDGET_MIME.to_string());
-            resource.size = Some(html.len() as u64);
+            resource.size = Some(widget.html.len() as u64);
             resource.meta = Some(widget_resource_meta());
             result.resources.push(resource);
         }
@@ -1678,13 +1698,13 @@ impl ServerHandler for YapMcp {
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, McpError> {
-        match (&self.widget, request.uri.as_str()) {
-            (Some(html), WIDGET_URI) => {
+        match &self.widget {
+            Some(widget) if widget.uri == request.uri => {
                 let mut result = ReadResourceResult::new(vec![]);
                 result.contents = vec![ResourceContents::TextResourceContents {
-                    uri: WIDGET_URI.to_string(),
+                    uri: widget.uri.clone(),
                     mime_type: Some(WIDGET_MIME.to_string()),
-                    text: html.as_ref().clone(),
+                    text: widget.html.clone(),
                     meta: Some(widget_resource_meta()),
                 }];
                 Ok(result)


### PR DESCRIPTION
Two fixes for the MCP Apps review widget (#123) failing in claude.ai after a deploy.

## What broke
Our MCP sessions lived in memory. The widget deploy replaced the machine minutes before the user tried it; claude.ai kept POSTing its stale `Mcp-Session-Id`; our spec-correct 404 surfaced through the Anthropic proxy as an opaque `mcp_session_terminated` / `-32600 "Invalid content from server"`. **Every deploy would re-break live conversations forever.**

## The fixes
- **Stateless streamable HTTP** — `stateful_mode = false` + `json_response = true`. No session ids exist, so nothing can go stale; each request is self-contained (auth was always a per-request bearer). Returns plain `application/json` instead of SSE framing.
- **Content-addressed widget URI** — `ui://yap/review.html@<12 hex of sha256(html)>`. Hosts cache `ui://` resources by URI and would keep rendering a stale iframe after every widget change; the URI now changes whenever the HTML does. Threaded through `list_tools` `_meta`, `list_resources`, and `read_resource`.
- **Smoke script** — asserts no session id is issued under stateless mode.

## Verification
`cargo build`/`clippy`/`test` clean; `cargo fmt` applied. Full end-to-end (OAuth + MCP) verification is the remote smoke script, run after deploy.

After this deploys, the connector must be removed and re-added once in claude.ai to shed its current broken session state; from then on deploys can't strand conversations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)