### PR TITLE
yap-mcp widget: scan reused frontend components for Tailwind classes

### DIFF
--- a/yap-mcp/widget/src/index.css
+++ b/yap-mcp/widget/src/index.css
@@ -2,6 +2,13 @@
    the widget is unmistakably yap. Host blending overrides live below. */
 @import "../../../yap-frontend/src/index.css";
 
+/* Tailwind v4 auto-scans only this Vite root (widget/) for class names, so
+   utilities used *only* inside the reused yap-frontend components (Card's
+   bg-card, Button's bg-primary/bg-destructive, shadows, rounded-xl…) would
+   never be generated — the card renders as a bare outline and the grade
+   buttons lose their fill. Point Tailwind at the reused component tree too. */
+@source "../../../yap-frontend/src/components";
+
 /* MCP Apps hosts render the widget inline in the conversation; a transparent
    body lets it sit on the host's surface (Claude's transparent-theming
    guidance) while cards/buttons keep yap's glassmorphism. */


### PR DESCRIPTION
The review widget (#123) rendered with almost no component styling — the card was a bare outline and the grade buttons lost their fills ("not much CSS").

## Cause
Tailwind v4 auto-scans only its Vite root (`yap-mcp/widget/`) for class names. Utilities used **only** inside the reused `yap-frontend` components — `Card`'s `bg-card`, `Button`'s `bg-primary`/`bg-destructive`, `shadow-xs`, `rounded-xl` — were never generated. Classes that also appear in the widget's own files (e.g. `border`) *did* emit, which is why an outline survived but the fills didn't.

## Fix
One `@source` directive pointing Tailwind at the reused component tree (`../../../yap-frontend/src/components`).

## Verification
- The previously-missing fill/shadow/variant classes now all appear in the built CSS.
- Rendered the real `ReviewCard` locally: the card gets its fill + shadow + squircle border, and on reveal both grade buttons show their color fills (Forgot = destructive red, Remembered = primary mauve) as one segmented control.

No new dependencies; system-font fallback left as-is by decision. Because of the content-addressed widget URI (#126), the new CSS changes the HTML hash, so claude.ai auto-refetches the fresh widget after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)