### PR TITLE
Suppress transient network/WASM errors from reaching Sentry

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -127,12 +127,14 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            // Skip network-level fetch failures (TypeError) and InvalidStateError
+            // Skip network-level fetch failures (TypeError), InvalidStateError,
+            // and SecurityError (blocked by browser privacy/extension settings)
             // — these are transient errors that aren't actionable bugs.
             if (
               navigator.onLine &&
               e?.name !== "InvalidStateError" &&
-              e?.name !== "TypeError"
+              e?.name !== "TypeError" &&
+              e?.name !== "SecurityError"
             ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }
@@ -1690,20 +1692,25 @@ export function useDeck():
       };
     } catch (error) {
       const errorMessage = getErrorMessage(error);
-      Sentry.captureException(error instanceof Error ? error : new Error(errorMessage), {
-        tags: {
-          "language-pack.target": course.targetLanguage,
-          "language-pack.native": course.nativeLanguage,
-          "language-pack.phase": "deck-state",
-        },
-        contexts: {
-          "language-pack": {
-            targetLanguage: course.targetLanguage,
-            nativeLanguage: course.nativeLanguage,
-            rawError: errorMessage,
+      const isNetworkError = errorMessage.startsWith("Network error:");
+      if (!isNetworkError) {
+        // Only report non-network errors to Sentry. Network failures are expected
+        // on flaky mobile connections and the user already sees a retry UI.
+        Sentry.captureException(error instanceof Error ? error : new Error(errorMessage), {
+          tags: {
+            "language-pack.target": course.targetLanguage,
+            "language-pack.native": course.nativeLanguage,
+            "language-pack.phase": "deck-state",
           },
-        },
-      });
+          contexts: {
+            "language-pack": {
+              targetLanguage: course.targetLanguage,
+              nativeLanguage: course.nativeLanguage,
+              rawError: errorMessage,
+            },
+          },
+        });
+      }
       return {
         type: "error",
         courseKey,

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -26,11 +26,15 @@ Sentry.init({
 
     // Filter WASM fetch failures on iOS/WKWebView. These are transient network
     // errors during .wasm module initialization — identifiable by "Load failed"
-    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
-    if (message === "Load failed") {
+    // (the iOS Safari message for a failed fetch, sometimes re-wrapped by
+    // wasm-bindgen as "TypeError: Load failed") with a WASM file in the stack.
+    // The module's top-level await means the rejection often carries no
+    // captured call stack at all, so an empty stacktrace also counts as a match.
+    if (message === "Load failed" || message === "TypeError: Load failed") {
       const frames =
         event.exception?.values?.[0]?.stacktrace?.frames ?? [];
       if (
+        frames.length === 0 ||
         frames.some(
           (f) =>
             f.filename?.includes("wasm-helper") ||
@@ -39,6 +43,13 @@ Sentry.init({
       ) {
         return null;
       }
+    }
+
+    // Chrome's equivalent of the above: the .wasm fetch's response stream
+    // aborts mid-flight, so WebAssembly.compile/instantiate reject with this.
+    if (message.startsWith("WebAssembly compilation aborted") ||
+        message.startsWith("WebAssembly instantiation aborted")) {
+      return null;
     }
 
     return event;


### PR DESCRIPTION
## Summary

Reviewed unresolved production Sentry issues on `javascript-react` and found three gaps in existing "don't report transient/expected errors" logic — each unambiguous and already following an established pattern elsewhere in the same file:

- **JAVASCRIPT-REACT-1J** (`Network error: JavaScript error: JsValue(...)`, recurring over months): `useDeck`'s deck-state build catch block reported every error unconditionally, unlike its sibling catch block a few lines above (language-pack fetch), which already skips `"Network error:"`-prefixed errors because they're expected on flaky mobile connections and the user already sees a retry UI. Applied the same guard.
- **JAVASCRIPT-REACT-2X** (`SecurityError: Script .../sw.js load failed`): the service-worker `r.update()` catch already ignores `TypeError`/`InvalidStateError` (added in #102) as non-actionable transient SW-registration failures, but not `SecurityError` (blocked by browser privacy/extension settings) — same category, just missing from the list.
- **JAVASCRIPT-REACT-2W / 2R** (`WebAssembly compilation aborted: ...`, `TypeError: Load failed` with no stacktrace): the `beforeSend` filter added in #102 for WASM top-level-await network failures only matched an exact `"Load failed"` message with WASM frames present in the stack. In practice the rejection sometimes arrives re-wrapped as `"TypeError: Load failed"` with no captured stack at all, and Chrome's variant reads `"WebAssembly compilation aborted: ..."`. Broadened the match to cover both.

Confirmed via git history that the other unresolved issues (1F, 2P, 2G — SW update `TypeError`s) are all pre-existing events from before #102's fix landed, i.e. already resolved by that prior commit and just stale in Sentry's UI.

No behavior change for real bugs — these are all cases where the exception is already caught and handled (user sees a retry UI / SW silently retries later), just previously still forwarded to Sentry as noise.

## Test plan

- [x] Manual review of the diff and cross-referenced against the actual Sentry event payloads (`error.type`/`error.value`/`error.mechanism`/release) to confirm each condition matches real production events
- [ ] `tsc -b` / `pnpm lint` (couldn't run in this sandbox — the `yap-frontend-rs/pkg` wasm build dependency isn't available here; changes are plain conditional/string-comparison logic with no new types)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MGaE8NZvPmdi1ZmSewBCae)_