### PR TITLE
rename: set_daily_review_target -> change_daily_review_target

### DIFF
--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -2771,7 +2771,7 @@ impl Deck {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-    pub fn set_daily_review_target(&self, daily_review_target: DailyReviewTarget) -> DeckEvent {
+    pub fn change_daily_review_target(&self, daily_review_target: DailyReviewTarget) -> DeckEvent {
         DeckEvent::Language(LanguageEvent {
             target_language: self.context.course.target_language,
             native_language: self.context.course.native_language,

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -1180,7 +1180,7 @@ function Review({
             targetLanguage={targetLanguage}
             dailyReviewTarget={deck.get_daily_review_target_setting()}
             onChangeDailyReviewTarget={(target: DailyReviewTarget) => {
-              const event = deck.set_daily_review_target(target);
+              const event = deck.change_daily_review_target(target);
               weapon.add_deck_event(event);
             }}
             onDismiss={() => setDismissedAccomplishment(true)}


### PR DESCRIPTION
## Summary

`Deck::set_daily_review_target` doesn't mutate `self` — like its sibling `change_sentence_list` (already renamed from `set_sentence_list` in #103), it just constructs and returns a `DeckEvent`; the caller has to separately call `add_deck_event` to apply it. The `set_` name reads as "assigns the deck's state directly," which is the wrong mental model — a reader would expect `deck.set_daily_review_target(target)` alone to change behavior, when in reality the returned event does nothing until dispatched. `change_` matches the existing renamed sibling and correctly signals "this describes a change to apply," not "this applies a change."

Before:
```rust
pub fn set_daily_review_target(&self, daily_review_target: DailyReviewTarget) -> DeckEvent { ... }
```
```ts
const event = deck.set_daily_review_target(target);
weapon.add_deck_event(event);
```
After:
```rust
pub fn change_daily_review_target(&self, daily_review_target: DailyReviewTarget) -> DeckEvent { ... }
```
```ts
const event = deck.change_daily_review_target(target);
weapon.add_deck_event(event);
```

Only the Rust method name and its one call site (`yap-frontend/src/App.tsx`) changed. The serialized event variant `LanguageEventContent::SetDailyReviewTarget` in `deck_event/current.rs` is untouched, since that type is serialized to disk and covered by the repo's event backwards-compatibility rule.

## Test plan

- [x] `cargo check -p yap-frontend-rs` — clean
- [x] `cargo clippy -p yap-frontend-rs` — clean
- [x] `cargo fmt -p yap-frontend-rs` — no changes needed
- [x] `cargo test -p yap-frontend-rs` — all tests pass
- [x] Grepped the whole repo for `set_daily_review_target` / `setDailyReviewTarget` — only the definition and the one call site existed, both updated
- [ ] Could not run `pnpm tsc -b` in this sandbox — it requires a `wasm-pack` build of `yap-frontend-rs/pkg`, and `wasm-pack` isn't installed here. The change is a mechanical rename with no signature/type changes, so risk is low.

## Note on branch history

This branch (`claude/elegant-noether-kdquwc`) already had ~20 unmerged commits of unrelated, real feature work (the yap-mcp MCP server + review widget) pushed to it before this session started, with no existing PR. Per this task's branch instructions I committed on top of it rather than resetting/force-pushing over that work. As a result this PR's diff includes those pre-existing commits in addition to the one-line rename above — they were not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015h55qEzNL6ziGmZSupZoMn)_