### PR TITLE
Filter more unactionable WASM/ServiceWorker noise from Sentry

### DIFF
--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -41,6 +41,33 @@ Sentry.init({
       }
     }
 
+    // Filter other known-unactionable WASM bootstrap failures. The WASM
+    // module uses top-level await, so a rejection here escapes every
+    // try/catch in our code and lands directly in the global handlers —
+    // there's no app-level place to catch it short of turning every static
+    // WASM import into a dynamic one.
+    if (
+      message.includes("WebAssembly compilation aborted") || // network interrupted the streaming compile
+      message.includes("WebAssembly is not defined") // environment strips/lacks the global entirely
+    ) {
+      return null;
+    }
+
+    // Filter ServiceWorker install/update failures caused by the browser
+    // being unable to fetch sw.js (flaky network, offline, blocked by an
+    // extension). Browsers disagree on the exception name for this — Chrome,
+    // Firefox, and Safari each surface a different `.name` (or none at all)
+    // for the same underlying condition — so match on the browser-generated
+    // message text instead, which is consistent across them.
+    if (
+      message.includes("yap.town") &&
+      (message.includes("encountered an error during installation") ||
+        message.startsWith("Failed to update a ServiceWorker for scope") ||
+        /^Script .* load failed$/.test(message))
+    ) {
+      return null;
+    }
+
     return event;
   },
 


### PR DESCRIPTION
## Summary

Reviewed the 8 currently-unresolved production issues in Sentry (project `javascript-react`). All of them are single-user, low-frequency, non-actionable environment/network conditions during app bootstrap — no genuine app-logic bug found. This extends the existing `beforeSend` noise filter (from #102) to cover the recurring patterns that slipped through:

- **`JAVASCRIPT-REACT-2Y`** (`ReferenceError: WebAssembly is not defined`) and **`JAVASCRIPT-REACT-2W`** (`WebAssembly compilation aborted: Network error...`) — same root cause as the already-filtered iOS "Load failed" case: the WASM module uses top-level `await`, so any failure here escapes every try/catch in our code and lands directly in the global error handlers. Fixing this properly would mean converting every static WASM import across the app to a dynamic one — a large refactor for a handful of single-user occurrences, so filtering matches the precedent already set for the iOS variant.

- **`JAVASCRIPT-REACT-1F`, `-2P`, `-2X`, `-2G`** (ServiceWorker install/update failures) — all route through the single `r.update().catch()` in `App.tsx`, which already tries to exclude these via `e.name !== "TypeError"`. That guard doesn't reliably work: Chrome, Firefox, and Safari disagree on the exception `.name` for this browser-generated rejection (that's why `1F` recurred on Firefox even after the #102 fix landed). Matching on the message text instead — which is consistent across browsers — actually filters them.

Left two issues untouched:
- `JAVASCRIPT-REACT-1J` (WASM network error) is already caught and reported deliberately (`handled: yes`, no crash) — working as intended.
- `JAVASCRIPT-REACT-2R` (`TypeError: TypeError: Load failed`) has no stacktrace available, so there isn't enough evidence to safely identify and filter its root cause without risking over-broad matching.

This is a monitoring-only change (`beforeSend` filtering) — no user-facing behavior changes.

## Test plan
- [x] `pnpm exec tsc -b` passes
- [x] `pnpm exec eslint src/instrument.ts` clean (pre-existing lint errors elsewhere are unrelated/unchanged)
- [ ] Confirm in Sentry that these issue patterns stop recurring after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BjZjUBw4Wiw7JvCtRTbEvZ)_