### PR TITLE
Filter unactionable Sentry noise: beacon.min.js and WASM network aborts

### DIFF
--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -18,18 +18,27 @@ Sentry.init({
 
   beforeSend(event) {
     const message = event.exception?.values?.[0]?.value ?? "";
+    const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
 
     // Filter out browser extension errors (not our code)
     if (message.includes("runtime.sendMessage()")) {
       return null;
     }
 
-    // Filter WASM fetch failures on iOS/WKWebView. These are transient network
-    // errors during .wasm module initialization — identifiable by "Load failed"
-    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
+    // Filter errors thrown from Cloudflare Web Analytics' beacon.min.js — a
+    // third-party script we don't control, injected outside our source tree.
+    // Old browsers (e.g. Chrome <92 lacking Array.prototype.at) crash inside
+    // it with nothing for us to fix.
+    if (frames.some((f) => f.filename?.includes("beacon.min.js"))) {
+      return null;
+    }
+
+    // Filter WASM fetch/compile failures caused by a dropped network
+    // connection during .wasm module initialization — identifiable by
+    // "Load failed" (the iOS Safari message for a failed fetch) with a WASM
+    // file in the stack, or by Chrome's "WebAssembly compilation aborted"
+    // message when streaming instantiation is interrupted mid-transfer.
     if (message === "Load failed") {
-      const frames =
-        event.exception?.values?.[0]?.stacktrace?.frames ?? [];
       if (
         frames.some(
           (f) =>
@@ -39,6 +48,9 @@ Sentry.init({
       ) {
         return null;
       }
+    }
+    if (message.startsWith("WebAssembly compilation aborted")) {
+      return null;
     }
 
     return event;


### PR DESCRIPTION
## Summary

Reviewed recent unresolved Sentry issues in `javascript-react`. Most turned out to trace back to one scanning/bot session on an ancient Chrome 75 / Android 6 device, or were already fixed by #102 but still open in Sentry.

- **`beacon.min.js` (Cloudflare Web Analytics) errors** (`t.entries.at is not a function`, `this.i.at is not a function`): this third-party script isn't in our source tree, and the crash is `Array.prototype.at` being unsupported on pre-Chrome-92 browsers — nothing for us to fix. Filtered in `beforeSend`, the same way browser-extension errors already are.
- **`WebAssembly compilation aborted: Network error: ...`**: this is Chrome's version of the dropped-connection-during-streaming-instantiate failure that `#102` already filters for Safari's "Load failed" message. Extended the same filter to catch it.
- Marked `JAVASCRIPT-REACT-2G`, `JAVASCRIPT-REACT-2P`, `JAVASCRIPT-REACT-2V` (all "Failed to update a ServiceWorker" TypeErrors) resolved in Sentry directly — they're already fixed by #102's broadened TypeError guard on `r.update()` and had no occurrences after it landed.

Left the old-browser `WebAssembly` CompileError/ReferenceError issues alone: they only occur on a browser that's already outside supported range (same one-off Chrome 75 session, 1 user total), and fixing the underlying race between the browser-support check and the WASM module's top-level import would mean converting static imports to dynamic ones across the app — a much bigger change than this low-volume edge case warrants.

## Test plan

- [x] Reviewed the diff by hand — pure addition to an existing `beforeSend` filter, no new imports or behavior changes to app code.
- [ ] Frontend `node_modules`/wasm pkg aren't built in this sandbox, so `tsc`/`eslint` couldn't run end-to-end; the change reuses existing types/patterns from the same function.

https://claude.ai/code/session_01Mc5wwiEBoetWMny1rVCT7j


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc5wwiEBoetWMny1rVCT7j)_