### PR TITLE
Filter two more transient Sentry errors (SW SecurityError, WASM streaming abort)

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -127,12 +127,15 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            // Skip network-level fetch failures (TypeError) and InvalidStateError
-            // — these are transient errors that aren't actionable bugs.
+            // Skip network-level fetch failures (TypeError), InvalidStateError, and
+            // SecurityError (thrown when the browser blocks SW registration/update,
+            // e.g. private browsing) — these are transient errors that aren't
+            // actionable bugs.
             if (
               navigator.onLine &&
               e?.name !== "InvalidStateError" &&
-              e?.name !== "TypeError"
+              e?.name !== "TypeError" &&
+              e?.name !== "SecurityError"
             ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -41,6 +41,14 @@ Sentry.init({
       }
     }
 
+    // Same category of transient network failure, but for the streaming-compile
+    // path: the browser aborts the .wasm response body mid-download (flaky
+    // connection), which surfaces as this WebAssembly-specific message rather
+    // than a generic "Load failed".
+    if (message.startsWith("WebAssembly compilation aborted: Network error")) {
+      return null;
+    }
+
     return event;
   },
 


### PR DESCRIPTION
## Summary

Reviewed the currently unresolved production Sentry issues in `javascript-react`. Two of them are recurrences of the exact non-actionable category already addressed by #102 ("Filter transient network errors from Sentry"), just with error variants the existing filters don't quite match:

- **JAVASCRIPT-REACT-2X** (`SecurityError: Script https://yap.town/sw.js load failed`): the periodic `registration.update()` check (`App.tsx`) already skips `TypeError`/`InvalidStateError` rejections as non-actionable transient browser conditions, but not `SecurityError` — which browsers throw when they block service worker updates entirely (e.g. private browsing). Added it to the exclusion list.
- **JAVASCRIPT-REACT-2W** (`TypeError: WebAssembly compilation aborted: Network error: Response body loading was aborted`): `instrument.ts`'s `beforeSend` already filters the `"Load failed"` WASM-fetch-failure message (from #102), but this is the streaming-compile variant of the same flaky-connection failure during `.wasm` module load, with a different message shape. Added a matching filter.

The other unresolved issues (`WebAssembly is not defined` in a browser/extension that disables the global, a stray `Load failed` unhandled rejection with no stack frames, and an old low-frequency wrapped network error) didn't have an unambiguous, narrowly-scoped fix — filtering them further risked masking real bugs or required larger changes than warranted for single-digit low-user-impact events, so they were left alone per guidance to avoid broad changes just to silence an issue.

## Test plan

- [x] Manually reviewed both diffs; both are narrow, mirror the existing precedent from #102 exactly.
- [x] Isolated `tsc --noEmit --noResolve` pass over `instrument.ts` confirmed no new syntax errors (only pre-existing unrelated module-resolution errors from missing `node_modules`).
- [ ] Could not run full `pnpm lint` / `tsc -b` / build in this sandbox: `yap-frontend-rs/pkg` isn't built here and `wasm-pack` isn't installed (the sandbox's network policy blocks fetching the installer from `rustwasm.github.io`), so `pnpm install` fails on the workspace's local WASM package link before lint/typecheck can run. Recommend running `pnpm lint` / `tsc -b` in CI or locally to confirm.

https://claude.ai/code/session_01Q7EwooWZQMKx6rx4s6GQEr


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7EwooWZQMKx6rx4s6GQEr)_