### PR TITLE
Handle SW registration errors and widen non-actionable Sentry filters

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -142,6 +142,13 @@ function AppMain() {
         setInterval(update, updateIntervalMS);
       }
     },
+    onRegisterError(e) {
+      // Skip network-level failures (TypeError) and browser lockdown errors
+      // (SecurityError) — these are transient/environmental, not actionable bugs.
+      if (e?.name !== "TypeError" && e?.name !== "SecurityError") {
+        Sentry.captureException(e, { tags: { "sw.register_error": true } });
+      }
+    },
   });
 
   return <AppCheckBrowserSupport />;

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -24,21 +24,46 @@ Sentry.init({
       return null;
     }
 
-    // Filter WASM fetch failures on iOS/WKWebView. These are transient network
-    // errors during .wasm module initialization — identifiable by "Load failed"
-    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
-    if (message === "Load failed") {
-      const frames =
-        event.exception?.values?.[0]?.stacktrace?.frames ?? [];
-      if (
-        frames.some(
-          (f) =>
-            f.filename?.includes("wasm-helper") ||
-            f.filename?.includes("_bg.wasm"),
-        )
-      ) {
-        return null;
-      }
+    // Filter third-party analytics beacon errors (not our code).
+    const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+    if (frames.some((f) => f.filename?.includes("beacon.min.js"))) {
+      return null;
+    }
+
+    // Filter WASM fetch/compile failures caused by flaky networks or browsers
+    // that predate WebAssembly / reference types. Nothing we can do about
+    // these beyond the existing browser-support check, which only runs once
+    // the module has already loaded.
+    if (
+      message.includes("WebAssembly is not defined") ||
+      message.includes("WebAssembly compilation aborted") ||
+      message.includes("WebAssembly.instantiateStreaming")
+    ) {
+      return null;
+    }
+
+    // Filter WASM load failures. Identifiable by the generic network-error
+    // text browsers use for a failed fetch ("Load failed" on iOS/WKWebView,
+    // "Failed to fetch" on Chromium, "NetworkError" on Firefox) together with
+    // a WASM file in the stack.
+    if (
+      (message.includes("Load failed") ||
+        message.includes("Failed to fetch") ||
+        message.includes("NetworkError")) &&
+      frames.some(
+        (f) =>
+          f.filename?.includes("wasm-helper") ||
+          f.filename?.includes("_bg.wasm"),
+      )
+    ) {
+      return null;
+    }
+
+    // Filter IndexedDB backing-store errors. This is a known browser/OS-level
+    // storage engine fault (not triggered by any of our own indexedDB calls)
+    // seen on constrained or aging devices — there's no app-level recovery.
+    if (message.includes("Internal error opening backing store")) {
+      return null;
     }
 
     return event;


### PR DESCRIPTION
## Summary

Reviewed recent unresolved production Sentry issues on `javascript-react` and found a small set of unhandled/non-actionable error classes worth addressing without restructuring how the app works:

- **`registerSW`/`useRegisterSW` had no `onRegisterError` handler** ([JAVASCRIPT-REACT-1F](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-1F), [JAVASCRIPT-REACT-2X](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2X)) — a failed initial service-worker registration (e.g. a `SecurityError` in a locked-down browser context) went completely unhandled. Added a handler mirroring the existing filtering already used for the periodic `update()` error path (skip transient `TypeError`/`SecurityError`, report anything else).
- **WASM init failures on incompatible/flaky environments** ([JAVASCRIPT-REACT-2Y](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2Y) `WebAssembly is not defined`, [JAVASCRIPT-REACT-26](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-26) `CompileError ... externref`, [JAVASCRIPT-REACT-2W](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2W) streaming-compile network abort) — these come from browsers that predate WebAssembly/reference-types support, or from flaky networks aborting the wasm fetch. The existing in-app browser-support check can't guard against these because the wasm module is imported as a side effect before any React code (including that check) runs — fixing that ordering would mean restructuring ~44 import sites, which felt like a disproportionate change for what's ultimately unfixable, non-actionable noise. Instead widened the existing `beforeSend` filter (which already special-cased one variant of this — "Load failed" + wasm stack frames) to also cover these messages, and to recognize the equivalent Chromium (`Failed to fetch`) and Firefox (`NetworkError`) fetch-failure strings alongside the WebKit one already handled.
- **Third-party `beacon.min.js` (web-vitals) errors** ([JAVASCRIPT-REACT-2T](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2T), [JAVASCRIPT-REACT-2S](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2S)) — `Array.prototype.at` calls failing on very old browsers, inside a third-party script we don't control. Filtered by stack frame filename, same pattern as the existing browser-extension filter.
- **Browser/OS-level IndexedDB backing-store faults** ([JAVASCRIPT-REACT-2H](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2H)) — a known storage-engine fault on constrained/aging devices, not triggered by any of our own `indexedDB` calls. Filtered by message.

Left [JAVASCRIPT-REACT-2R](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2R) (`TypeError: Load failed` with no stacktrace) and [JAVASCRIPT-REACT-1J](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-1J) (already-handled network error surfaced from the Rust layer) alone — there's no stack evidence to safely attribute either to WASM loading versus a real bug, so filtering them risked hiding a genuine issue.

## Test plan

- [x] Read through both diffs carefully for syntax/type correctness (`onRegisterError` is a standard, documented `vite-plugin-pwa` `RegisterSWOptions` field).
- [ ] Could not run `pnpm install` / `tsc -b` in this environment — building the `yap-frontend-rs` wasm package requires `wasm-pack`, which isn't available here. Recommend CI confirms typecheck/build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aqKsABbThaCVkbpHs9YVM


---
_Generated by [Claude Code](https://claude.ai/code/session_012aqKsABbThaCVkbpHs9YVM)_