### PR TITLE
Guard app entry against missing WebAssembly global

### DIFF
--- a/yap-frontend/src/main.tsx
+++ b/yap-frontend/src/main.tsx
@@ -6,19 +6,41 @@ import { reactErrorHandler } from "@sentry/react";
 import "@fontsource-variable/nunito";
 import "@fontsource-variable/nunito-sans";
 import "./index.css";
-import App from "./App.tsx";
 
 // Hide the loading screen once React mounts
 if (typeof window !== "undefined" && (window as any).hideLoadingScreen) {
   (window as any).hideLoadingScreen();
 }
 
-createRoot(document.getElementById("root")!, {
+const root = createRoot(document.getElementById("root")!, {
   onUncaughtError: reactErrorHandler(),
   onCaughtError: reactErrorHandler(),
   onRecoverableError: reactErrorHandler(),
-}).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+});
+
+// App.tsx (and its dependency graph) statically imports the WASM module, which
+// references the global `WebAssembly` object as soon as it's evaluated. On
+// browsers/environments where WebAssembly is unavailable (e.g. hardened
+// privacy browsers), that import throws a ReferenceError before React ever
+// mounts. Check for WebAssembly first and dynamically import App only when
+// it's present, so unsupported browsers get the normal "not supported" screen
+// instead of a blank crash.
+if (typeof WebAssembly === "undefined") {
+  import("./components/browser-not-supported").then(
+    ({ BrowserNotSupported }) => {
+      root.render(
+        <StrictMode>
+          <BrowserNotSupported />
+        </StrictMode>,
+      );
+    },
+  );
+} else {
+  import("./App.tsx").then(({ default: App }) => {
+    root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Sentry issue [JAVASCRIPT-REACT-2Y](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2Y) is an uncaught `ReferenceError: WebAssembly is not defined`, thrown from the vite-plugin-wasm helper while evaluating the WASM module.
- `App.tsx` (and its dependency graph, e.g. `weapon.tsx`) statically imports the WASM module. Static ES module imports are evaluated immediately, so on any browser/environment where the `WebAssembly` global doesn't exist (e.g. hardened privacy browsers), this throws before React ever mounts — well before the existing `useWeaponSupport()` browser-support check ever gets a chance to run. The result is a blank page instead of the app's normal "Browser Not Supported" screen.
- `main.tsx` now checks `typeof WebAssembly === "undefined"` up front and dynamically imports either `App` or the existing `BrowserNotSupported` component accordingly, so the WASM module graph is only pulled in once we know `WebAssembly` exists.

I also looked at the other unresolved production issues in Sentry (service worker install/load failures, a WASM-compile network abort, a generic "Load failed"). All of those are transient network/browser-level failures — not caused by an identifiable bug in our code — and I intentionally didn't touch them to avoid papering over real signal or making speculative changes.

## Test plan

- [x] `tsc -b` passes
- [x] `pnpm build` produces the expected code-split chunks (`App-*.js`, `browser-not-supported-*.js` load lazily from `main.tsx`)
- [x] Confirmed the only lint errors touching `main.tsx` (`no-explicit-any` on the pre-existing `window as any` casts) predate this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvYGKyZeHhZYATEy5BXNjb)_