### PR TITLE
rename: intern_gram -> get_interned_gram

### DIFF
--- a/language-utils/src/language_pack.rs
+++ b/language-utils/src/language_pack.rs
@@ -69,9 +69,9 @@ pub struct LanguagePack {
 }
 
 impl LanguagePack {
-    /// Intern a resolved gram back into this pack's rodeos. Returns None if
-    /// any token, or the gram itself, was never interned.
-    pub fn intern_gram(&self, gram: &Gram<String>) -> Option<SpurGram> {
+    /// Look up a resolved gram's already-interned form in this pack's rodeos.
+    /// Returns None if any token, or the gram itself, was never interned.
+    pub fn get_interned_gram(&self, gram: &Gram<String>) -> Option<SpurGram> {
         gram.get_interned(&self.string_rodeo)?
             .get_interned(&self.gram_rodeo)
     }
@@ -83,9 +83,10 @@ impl LanguagePack {
         self.gram_frequencies.entries.contains_key(gram)
     }
 
-    /// Intern a gram and require it to be a real course entry.
+    /// Look up a gram's interned form and require it to be a real course entry.
     pub fn course_gram(&self, gram: &Gram<String>) -> Option<SpurGram> {
-        self.intern_gram(gram).filter(|g| self.is_course_gram(g))
+        self.get_interned_gram(gram)
+            .filter(|g| self.is_course_gram(g))
     }
 
     /// Resolve an interned gram back to its owned string form.


### PR DESCRIPTION
## Why the old name was misleading

`language-utils` has a rigorous, extremely consistent naming convention used by every type in the crate (`Word`, `Literal`, `Heteronym`, `Lexeme`, `Atom`, `Gram`, `SentenceGram`, `GramVocabEntry`, and more): a matched pair of methods, `get_or_intern(&self, rodeo: &mut lasso::Rodeo)` which actually inserts, and `get_interned(&self, rodeo: &lasso::RodeoReader)` which is a pure read-only lookup that returns `None` if the value was never interned.

`LanguagePack::intern_gram` broke that vocabulary. Its body is nothing but two chained `.get_interned()` calls, and its fields (`string_rodeo`, `gram_rodeo`) are `RodeoReader`, which is structurally incapable of insertion — this method can never intern anything. Its name and doc comment ("Intern a resolved gram back into this pack's rodeos") told the opposite story from what the code does, so a reader familiar with the crate's own `get_or_intern`/`get_interned` split would reasonably but wrongly assume it inserts.

`get_interned_gram` matches the crate's real vocabulary: "get" (read-only) + "interned" (already-interned lookup, not insertion) + "gram" (what it returns, since it composes two rodeos rather than being a trait method on the string-typed value itself). I also fixed `course_gram`'s doc comment, which used the same wrong "Intern a gram..." wording for a call that goes through this same read-only path.

Before:
```rust
/// Intern a resolved gram back into this pack's rodeos. Returns None if
/// any token, or the gram itself, was never interned.
pub fn intern_gram(&self, gram: &Gram<String>) -> Option<SpurGram> { ... }
```
After:
```rust
/// Look up a resolved gram's already-interned form in this pack's rodeos.
/// Returns None if any token, or the gram itself, was never interned.
pub fn get_interned_gram(&self, gram: &Gram<String>) -> Option<SpurGram> { ... }
```

Only the one definition and its one call site (`course_gram`, same file) reference this name — grepped the whole repo (`.rs`, `.ts`, `.tsx`, `.md`) to confirm no other references.

## Test plan

- [x] `cargo check -p language-utils` — clean
- [x] `cargo check --workspace` — clean (only a pre-existing, unrelated `nom` future-incompat warning)
- [x] `cargo clippy -p language-utils -p yap-frontend-rs -p yap-mcp` — clean
- [x] `cargo test -p language-utils` — 36 passed
- [x] `cargo fmt -p language-utils` — applied (wrapped the `course_gram` filter call)
- [x] Grepped the whole repo for `intern_gram` — only the renamed definition and call site existed, both updated

## Note on branch history

Like PR #129 before it, this branch (`claude/elegant-noether-i72wy7`) already had ~11 unmerged commits of unrelated, real feature work (passkey/WebAuthn sign-in, yap-mcp widget changes) pushed to it before this session started, with no existing PR. Per this task's branch instructions I committed on top of it rather than resetting/force-pushing over that work. As a result this PR's diff includes those pre-existing commits in addition to the one-file rename above — they were not introduced by this change and predate this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015diVeD7nA3k9hWYXjjSSR4

---
_Generated by [Claude Code](https://claude.ai/code/session_015diVeD7nA3k9hWYXjjSSR4)_