### PR TITLE
Fix uncaught WASM-load crash and quiet transient-network Sentry noise

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -128,12 +128,14 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            // Skip network-level fetch failures (TypeError) and InvalidStateError
+            // Skip network-level fetch failures (TypeError), InvalidStateError,
+            // and AbortError (update cancelled by a concurrent navigation/unload)
             // — these are transient errors that aren't actionable bugs.
             if (
               navigator.onLine &&
               e?.name !== "InvalidStateError" &&
-              e?.name !== "TypeError"
+              e?.name !== "TypeError" &&
+              e?.name !== "AbortError"
             ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }

--- a/yap-frontend/src/components/LanguageSelector.tsx
+++ b/yap-frontend/src/components/LanguageSelector.tsx
@@ -293,7 +293,12 @@ export function LanguageSelector({
           targetLanguage: selectionState.targetLanguage,
         })
         .catch((e: unknown) => {
-          Sentry.captureException(e);
+          // Skip network errors — expected on flaky mobile connections and
+          // not actionable; see the same filter in useDeck's language-pack load.
+          const message = e instanceof Error ? e.message : String(e);
+          if (!message.startsWith("Network error:")) {
+            Sentry.captureException(e);
+          }
         });
     }
   }, [selectionState, weapon]);

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -41,6 +41,13 @@ Sentry.init({
       }
     }
 
+    // Filter WASM streaming-compilation failures caused by the network
+    // connection dropping mid-download. This is Chrome's exact message for
+    // that case, so it can't be confused with an unrelated bug.
+    if (message.startsWith("WebAssembly compilation aborted")) {
+      return null;
+    }
+
     return event;
   },
 

--- a/yap-frontend/src/main.tsx
+++ b/yap-frontend/src/main.tsx
@@ -6,19 +6,43 @@ import { reactErrorHandler } from "@sentry/react";
 import "@fontsource-variable/nunito";
 import "@fontsource-variable/nunito-sans";
 import "./index.css";
-import App from "./App.tsx";
 
-// Hide the loading screen once React mounts
-if (typeof window !== "undefined" && (window as any).hideLoadingScreen) {
-  (window as any).hideLoadingScreen();
+function hideLoadingScreen() {
+  if (typeof window !== "undefined" && (window as any).hideLoadingScreen) {
+    (window as any).hideLoadingScreen();
+  }
 }
 
-createRoot(document.getElementById("root")!, {
+const root = createRoot(document.getElementById("root")!, {
   onUncaughtError: reactErrorHandler(),
   onCaughtError: reactErrorHandler(),
   onRecoverableError: reactErrorHandler(),
-}).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+});
+
+// App.tsx imports the yap-frontend-rs WASM module at the top level, which
+// runs the wasm-loading code as soon as that module is evaluated — before
+// any in-app "browser not supported" screen gets a chance to render. On
+// browsers without a WebAssembly global, that throws an uncaught
+// ReferenceError and the page is left blank. Check for WebAssembly here,
+// ahead of the import, so those browsers get the fallback screen instead.
+if (typeof WebAssembly === "undefined") {
+  import("./components/browser-not-supported").then(
+    ({ BrowserNotSupported }) => {
+      hideLoadingScreen();
+      root.render(
+        <StrictMode>
+          <BrowserNotSupported />
+        </StrictMode>,
+      );
+    },
+  );
+} else {
+  import("./App.tsx").then(({ default: App }) => {
+    hideLoadingScreen();
+    root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Went through recent production Sentry issues on `javascript-react`. Most were one-off, unfixable browser/network quirks, but a few traced to a real bug or to noise the code already has a documented policy of filtering elsewhere:

- **`ReferenceError: WebAssembly is not defined`** ([JAVASCRIPT-REACT-2Y](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2Y)) — `main.tsx` imported `App.tsx` (and transitively the yap-frontend-rs WASM module) unconditionally at module-eval time. On a browser without a `WebAssembly` global, that throws an uncaught `ReferenceError` before the app's own "browser not supported" screen (`useWeaponSupport`/`BrowserNotSupported`) ever gets a chance to render — the user just sees a blank page. Fixed by checking `typeof WebAssembly === "undefined"` in `main.tsx` and lazy-loading (`import()`) either `App.tsx` or the `BrowserNotSupported` fallback accordingly, so the WASM-loading code is never even fetched on unsupported browsers. Verified with a production build: `App-*.js` (pulls in the wasm module) and `browser-not-supported-*.js` are now separate chunks.
- **`AbortError: Failed to update a ServiceWorker...`** ([JAVASCRIPT-REACT-2Z](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2Z)) — the periodic `r.update()` catch in `App.tsx` already excludes `TypeError`/`InvalidStateError` as non-actionable transient errors; added `AbortError` (update cancelled by a concurrent navigation/unload) to the same list.
- **`TypeError: WebAssembly compilation aborted: Network error...`** ([JAVASCRIPT-REACT-2W](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-2W)) — extended the existing Sentry `beforeSend` WASM-network-noise filter to also drop this message, Chrome's exact wording for a WASM streaming compile interrupted by a dropped connection (same class of issue the existing "Load failed" filter already targets).
- **`Network error: JsValue(TypeError: network error...)`** ([JAVASCRIPT-REACT-1J](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-1J)) — `cache_language_pack`'s error handler in `LanguageSelector.tsx` reported every failure to Sentry, including plain transport errors. Applied the same `"Network error:"`-prefix filter already used by `useDeck`'s language-pack loader in `App.tsx` for the identical scenario.

Left the remaining unresolved issues alone (service worker install failures, generic Safari/mobile fetch failures with no stack trace) since they're single-occurrence, environment-specific noise (private browsing, flaky mobile networks, browser extensions) with no clear, safe code-level fix.

## Test plan

- [x] `tsc -b` passes
- [x] `pnpm lint` — confirmed no new violations from this change (diffed against the pre-change lint output; all remaining warnings/errors are pre-existing and untouched by this PR)
- [x] `pnpm build` succeeds; verified in the output that `App-*.js` and `browser-not-supported-*.js` are separate chunks, confirming the WASM module is never fetched when the `WebAssembly` check fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GpbNNB7NeYwF2qVpz5bY9b

---
_Generated by [Claude Code](https://claude.ai/code/session_01GpbNNB7NeYwF2qVpz5bY9b)_