### PR TITLE
Filter more transient SW update errors from Sentry

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -128,13 +128,18 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            // Skip network-level fetch failures (TypeError) and InvalidStateError
-            // — these are transient errors that aren't actionable bugs.
-            if (
-              navigator.onLine &&
-              e?.name !== "InvalidStateError" &&
-              e?.name !== "TypeError"
-            ) {
+            // Skip transient, non-actionable failures of the background sw.js
+            // fetch: network errors (TypeError), an update already in flight
+            // (InvalidStateError), the request getting cancelled (AbortError),
+            // and browser security policies blocking the fetch (SecurityError,
+            // e.g. storage-partitioning restrictions on iOS).
+            const transientErrors = [
+              "InvalidStateError",
+              "TypeError",
+              "AbortError",
+              "SecurityError",
+            ];
+            if (navigator.onLine && !transientErrors.includes(e?.name)) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }
           });


### PR DESCRIPTION
## Summary

Reviewed recent unresolved Sentry issues in production. Two of them —
`JAVASCRIPT-REACT-2Z` (`AbortError: Failed to update a ServiceWorker...`)
and `JAVASCRIPT-REACT-2X` (`SecurityError: Script https://yap.town/sw.js
load failed`) — come from the periodic background `sw.js` update check in
`AppMain` (`yap-frontend/src/App.tsx`).

This is the exact same class of non-actionable, environment-caused failure
that `#102` already filtered out for `TypeError`/`InvalidStateError`: the
browser cancelling the update fetch (`AbortError`) or a security policy
blocking it (`SecurityError`, e.g. storage-partitioning restrictions on
iOS/Edge Mobile) — not an application bug. This PR extends the existing
exclusion list with those two error names instead of introducing a
separate one-off filter.

A third issue, `JAVASCRIPT-REACT-1F` (`TypeError` during SW installation),
looks to already be resolved by `#102` — its last occurrence (Jul 8) lines
up with that fix landing, and it hasn't recurred in the two weeks since.

Two other unresolved issues were investigated but left alone as
out-of-scope for a minimal fix:
- `JAVASCRIPT-REACT-2Y` (`ReferenceError: WebAssembly is not defined`) —
  a single user in an environment without a `WebAssembly` global. Fixing
  this cleanly would require converting `main.tsx`'s static `App.tsx`
  import into a dynamic import so a "browser not supported" screen can be
  shown before the WASM module loads, which affects initial-load behavior
  for every user — too large a change for one non-repeating occurrence.
- `JAVASCRIPT-REACT-30` (`AbortError: The connection was closed.`) — a
  single occurrence with no stack trace, so there's no way to identify
  which code path needs a fix without guessing.

## Test plan

- [x] Reviewed the diff by hand (small, type-safe change; `e` in the
      `.catch` callback is `any`, so `.includes()` compiles fine)
- [ ] Rely on CI for `tsc`/`eslint` (WASM toolchain isn't available in this
      sandbox to build `yap-frontend-rs/pkg` and run a local typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgWC84pMvDeKyoX4tNWjG9


---
_Generated by [Claude Code](https://claude.ai/code/session_01GgWC84pMvDeKyoX4tNWjG9)_