### PR TITLE
Filter more transient WASM/SW load noise from Sentry

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -128,12 +128,16 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            // Skip network-level fetch failures (TypeError) and InvalidStateError
-            // — these are transient errors that aren't actionable bugs.
+            // Skip network-level fetch failures (TypeError), InvalidStateError,
+            // AbortError (update superseded/cancelled), and SecurityError (e.g.
+            // Safari Private Browsing, which disables service workers) — these
+            // are transient errors that aren't actionable bugs.
             if (
               navigator.onLine &&
               e?.name !== "InvalidStateError" &&
-              e?.name !== "TypeError"
+              e?.name !== "TypeError" &&
+              e?.name !== "AbortError" &&
+              e?.name !== "SecurityError"
             ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -24,10 +24,19 @@ Sentry.init({
       return null;
     }
 
-    // Filter WASM fetch failures on iOS/WKWebView. These are transient network
-    // errors during .wasm module initialization — identifiable by "Load failed"
-    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
-    if (message === "Load failed") {
+    // Filter WASM module load failures. These are all transient/environmental
+    // conditions during .wasm module initialization, not application bugs:
+    // "Load failed" (Safari's fetch failure message), "Failed to fetch"
+    // (Chrome/Firefox's), and "WebAssembly is not defined" (extensions or
+    // embedded webviews that strip the WebAssembly global). Identified by the
+    // vite-generated WASM loader appearing in the stack — these messages are
+    // generic enough (e.g. "Load failed" also covers other fetches) that we
+    // only drop them when the WASM loader is actually on the stack.
+    if (
+      message === "Load failed" ||
+      message === "Failed to fetch" ||
+      message === "WebAssembly is not defined"
+    ) {
       const frames =
         event.exception?.values?.[0]?.stacktrace?.frames ?? [];
       if (
@@ -39,6 +48,14 @@ Sentry.init({
       ) {
         return null;
       }
+    }
+
+    // Chrome's own message when `WebAssembly.instantiateStreaming()` gets cut
+    // off mid-download — unambiguously our single WASM module load (that's
+    // the only streaming-instantiate call site in the app), so no frame check
+    // needed here.
+    if (message.startsWith("WebAssembly compilation aborted")) {
+      return null;
     }
 
     return event;


### PR DESCRIPTION
## Summary

Reviewed the last ~90 days of unresolved production issues in Sentry (`yaptown`/`javascript-react`). Most are single-occurrence, environment-specific errors (missing stack traces, one user, one event) that aren't safely actionable. Two clusters, however, are clearly the same class of already-recognized noise that a prior fix (#102) started filtering, so this extends that same pattern:

- **WASM module load failures** (`JAVASCRIPT-REACT-2Y`, `JAVASCRIPT-REACT-2J`, `JAVASCRIPT-REACT-2W`): the vite-generated WASM loader can fail for purely environmental reasons — a network hiccup mid-fetch, or a browser extension/embedded webview that strips the `WebAssembly` global entirely. `instrument.ts`'s `beforeSend` already dropped Safari's `"Load failed"` message when the WASM loader is on the stack; this extends it to Chrome/Firefox's `"Failed to fetch"` and `"WebAssembly is not defined"` (same frame-based scoping, so it stays limited to WASM loading and won't swallow unrelated fetch failures elsewhere in the app), plus Chrome's `"WebAssembly compilation aborted: ..."` message for an interrupted streaming instantiation (matched directly since that message can only originate from our one `WebAssembly.instantiateStreaming()` call site).

- **Service worker update failures** (`JAVASCRIPT-REACT-2Z`, `JAVASCRIPT-REACT-2X`): the periodic `registration.update()` check already skips `TypeError`/`InvalidStateError` as transient, non-actionable failures. Extends that to `AbortError` (update superseded/cancelled) and `SecurityError` (e.g. Safari Private Browsing, which disables service workers entirely).

`JAVASCRIPT-REACT-1F` looks already resolved by the prior `TypeError` filter — its last occurrence ran on a release that predates that fix, and it hasn't recurred in the 15 days since. `JAVASCRIPT-REACT-30`, `-2R`, and `-1J` lack stack traces or an unambiguous single origin, so I left them alone rather than guess.

## Test plan

- [x] `cd yap-frontend-rs && wasm-pack build --features local-backend`
- [x] `cd yap-frontend && npx tsc -b` — passes
- [x] `cd yap-frontend && pnpm lint` — no new errors/warnings introduced (pre-existing lint issues in other files are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013rsLJmkK12pcdyNtjiG7uS

---
_Generated by [Claude Code](https://claude.ai/code/session_013rsLJmkK12pcdyNtjiG7uS)_