### PR TITLE
Fix duplicate service worker registration causing Sentry noise

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -64,7 +64,6 @@ import { LandingPage } from "@/pages/landing";
 import { NotFoundPage } from "@/pages/not-found";
 import { SentenceListsPage } from "@/pages/sentence-lists";
 import { playSoundEffect } from "@/lib/sound-effects";
-import { registerSW } from "virtual:pwa-register";
 import { NoCardsReady } from "@/components/no-cards-ready";
 import { AccomplishmentScreen } from "@/components/AccomplishmentScreen";
 import { useSentenceList, sentenceListToSelection } from "@/hooks/useSentenceList";
@@ -119,9 +118,6 @@ export type AppContextType = {
 
 function AppMain() {
   const updateIntervalMS = 60 * 5 * 1000; // every 5 minutes
-  useEffect(() => {
-    registerSW({ immediate: true });
-  }, []);
 
   useRegisterSW({
     onRegistered(r) {

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -24,10 +24,17 @@ Sentry.init({
       return null;
     }
 
-    // Filter WASM fetch failures on iOS/WKWebView. These are transient network
-    // errors during .wasm module initialization — identifiable by "Load failed"
-    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
-    if (message === "Load failed") {
+    // Filter transient failures fetching/instantiating the WASM module. These
+    // happen when the network drops or a browser extension/security policy
+    // interferes mid-fetch — identifiable by the vite wasm-helper or _bg.wasm
+    // file in the stack, regardless of which error message the browser used
+    // ("Load failed" on iOS Safari, "Failed to fetch" elsewhere, or
+    // "WebAssembly is not defined" when something clears the global mid-load).
+    if (
+      message === "Load failed" ||
+      message === "Failed to fetch" ||
+      message === "WebAssembly is not defined"
+    ) {
       const frames =
         event.exception?.values?.[0]?.stacktrace?.frames ?? [];
       if (


### PR DESCRIPTION
## Summary

While reviewing recent production issues in Sentry, I found that `AppMain` in `App.tsx` registers the service worker **twice** on every load:

- once via a bare `registerSW({ immediate: true })` call (from `virtual:pwa-register`)
- again via `useRegisterSW({ onRegistered ... })` (from `virtual:pwa-register/react`)

Both `registerSW` and `useRegisterSW` independently construct their own `Workbox` instance and call `wb.register()` — so every page load kicks off two concurrent, competing service-worker registrations against the same scope/script. That's a strong candidate for several unresolved Sentry issues seen this week:

- `AbortError: The connection was closed.` (JAVASCRIPT-REACT-30)
- `AbortError: Failed to update a ServiceWorker ... Operation has been aborted` (JAVASCRIPT-REACT-2Z)
- `SecurityError: Script https://yap.town/sw.js load failed` (JAVASCRIPT-REACT-2X)

This removes the redundant `registerSW` call/import and keeps the single `useRegisterSW` registration, which already drives the periodic update-check logic.

Separately, two other unresolved issues (JAVASCRIPT-REACT-2Y `ReferenceError: WebAssembly is not defined`, JAVASCRIPT-REACT-2J `TypeError: Failed to fetch`) both originate from the exact same `vite-plugin-wasm-helper` code path as an already-filtered case (`"Load failed"` on iOS Safari, added in #102). I widened that existing `beforeSend` filter to also cover these two message variants of the same transient WASM-load failure, rather than adding a new special case.

## Changes
- `yap-frontend/src/App.tsx`: remove the redundant `registerSW({ immediate: true })` call/import; `useRegisterSW` remains the single source of SW registration.
- `yap-frontend/src/instrument.ts`: broaden the WASM-fetch-failure Sentry filter to also match `"Failed to fetch"` and `"WebAssembly is not defined"` when they originate from the wasm-helper/`_bg.wasm` stack frames.

## Test plan
- [x] Read through `dist/client/build/register.ts` from the installed `vite-plugin-pwa` version to confirm `registerSW` and `useRegisterSW` each create an independent `Workbox` registration (no dependency between them).
- [x] Confirmed via `git log -S` that both calls were introduced in the same original commit, i.e. never intentionally split for a reason.
- [ ] Could not run `pnpm build`/`tsc` locally in this environment (requires a `wasm-pack` build of `yap-frontend-rs` first, which wasn't feasible here) — the diff is a straightforward import/effect removal and a same-shape string-literal addition, so risk is low, but worth a CI check.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Tf5WW3fQ8iM4c2GmGqDwUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tf5WW3fQ8iM4c2GmGqDwUA)_