### PR TITLE
Fix Sentry beforeSend filter for WASM init failures, exclude AbortError SW noise

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -128,12 +128,14 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            // Skip network-level fetch failures (TypeError) and InvalidStateError
-            // — these are transient errors that aren't actionable bugs.
+            // Skip network-level fetch failures (TypeError), InvalidStateError,
+            // and AbortError (connection dropped mid-update) — these are
+            // transient errors that aren't actionable bugs.
             if (
               navigator.onLine &&
               e?.name !== "InvalidStateError" &&
-              e?.name !== "TypeError"
+              e?.name !== "TypeError" &&
+              e?.name !== "AbortError"
             ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -17,28 +17,35 @@ Sentry.init({
   ],
 
   beforeSend(event) {
-    const message = event.exception?.values?.[0]?.value ?? "";
+    const value = event.exception?.values?.[0];
+    const message = value?.value ?? "";
+    const type = value?.type ?? "";
 
     // Filter out browser extension errors (not our code)
     if (message.includes("runtime.sendMessage()")) {
       return null;
     }
 
-    // Filter WASM fetch failures on iOS/WKWebView. These are transient network
-    // errors during .wasm module initialization — identifiable by "Load failed"
-    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
-    if (message === "Load failed") {
-      const frames =
-        event.exception?.values?.[0]?.stacktrace?.frames ?? [];
-      if (
-        frames.some(
-          (f) =>
-            f.filename?.includes("wasm-helper") ||
-            f.filename?.includes("_bg.wasm"),
-        )
-      ) {
-        return null;
-      }
+    // Filter WASM module init failures: transient network errors while
+    // fetching/instantiating the .wasm binary (e.g. "Load failed", the
+    // iOS Safari/WKWebView message for a failed fetch), and browsers that
+    // lack a WebAssembly global entirely. These come from Vite's wasm-loader
+    // helper, whose stack frames are only resolved to a recognizable
+    // filename after Sentry applies sourcemaps server-side — beforeSend only
+    // ever sees the raw bundled chunk URL, so match on message text instead.
+    if (message === "Load failed" || message === "WebAssembly is not defined") {
+      return null;
+    }
+
+    // Service worker update checks interrupted by a dropped connection —
+    // transient and not actionable, same class as the TypeError/
+    // InvalidStateError already excluded around the sw.update() call.
+    if (
+      type === "AbortError" &&
+      (message.includes("The connection was closed") ||
+        message.includes("Failed to update a ServiceWorker"))
+    ) {
+      return null;
     }
 
     return event;


### PR DESCRIPTION
## Summary

Reviewed the last two weeks of unresolved production Sentry issues and found that several were noise from a broken filter, not real app bugs:

- **JAVASCRIPT-REACT-2J** (`TypeError: Load failed`, regressed, still recurring): the `beforeSend` filter meant to suppress transient WASM-fetch failures checked stack-frame `filename`s for `"wasm-helper"`/`"_bg.wasm"`. But `beforeSend` runs on the raw client event *before* Sentry resolves sourcemaps server-side, so those substrings never actually appear in the frames it sees — the filter was silently dead code, which is why this issue kept resurfacing despite the existing intent to filter it. Fixed by matching on the exception message instead (which is what actually gets checked correctly).
- **JAVASCRIPT-REACT-2Y** (`ReferenceError: WebAssembly is not defined`): same class of non-actionable WASM-init failure (browser with no `WebAssembly` global), now filtered the same way.
- **JAVASCRIPT-REACT-2Z** (`AbortError: Failed to update a ServiceWorker...Operation has been aborted`) and **JAVASCRIPT-REACT-30** (`AbortError: The connection was closed.`): both fired from the same dropped-connection event during a service-worker update check. The existing `sw.update()` catch handler already excludes `TypeError`/`InvalidStateError` as known-transient, non-actionable errors — extended that same exclusion to `AbortError`, and added a matching `beforeSend` filter for the unhandled-rejection variant that isn't caught by our own `.catch()`.

Left alone:
- **JAVASCRIPT-REACT-32** (`RuntimeError: unreachable` / Rust OOM panic during language-pack deserialization) — real memory pressure on a single low-memory Android tablet; fixing it properly would mean restructuring language-pack loading to be lazy/streaming, out of scope for a one-off noise cleanup.
- **JAVASCRIPT-REACT-31** (`t.request_deck_selection is not a function`) — the method has existed in `lib.rs` since well before this occurrence; single event, looks like a stale-cache/PWA version-skew edge case rather than something fixable with a small code change.

## Test plan

- [x] Reviewed diff for correctness against the actual Sentry event payloads (message/type fields) for each filtered issue
- [ ] Could not run `pnpm tsc`/`pnpm lint` in this environment — `yap-frontend` depends on the local `yap-frontend-rs/pkg` WASM build, and `wasm-pack`/network access to install it weren't available here. Changes are two small, self-contained TS edits with no new imports.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01C2xffZ3TsdeZs5ismVxWq7

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2xffZ3TsdeZs5ismVxWq7)_