### PR TITLE
Fix Sentry-reported unhandled exceptions from SW updates and route crashes

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -128,12 +128,15 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            // Skip network-level fetch failures (TypeError) and InvalidStateError
-            // — these are transient errors that aren't actionable bugs.
+            // Skip network-level fetch failures (TypeError), InvalidStateError,
+            // and AbortError (the update fetch getting cancelled by page
+            // unload/navigation) — these are transient errors that aren't
+            // actionable bugs.
             if (
               navigator.onLine &&
               e?.name !== "InvalidStateError" &&
-              e?.name !== "TypeError"
+              e?.name !== "TypeError" &&
+              e?.name !== "AbortError"
             ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }
@@ -1292,6 +1295,28 @@ function Review({
   );
 }
 
+// Not manually reported to Sentry here: @sentry/react's React 19 integration
+// already captures errors caught by any error boundary (including react-router's
+// own) via ReactDOM's onCaughtError hook.
+function RouteErrorFallback() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Card className="max-w-md w-full p-6 text-center gap-0">
+        <div className="w-12 h-12 bg-red-100 dark:bg-red-900/20 rounded-full flex items-center justify-center mx-auto mb-4">
+          <span className="text-red-600 dark:text-red-400 text-xl">⚠</span>
+        </div>
+        <h2 className="text-lg font-semibold mb-2">Something went wrong</h2>
+        <p className="text-muted-foreground mb-4">
+          Yap.Town ran into an unexpected error. Reloading usually fixes it.
+        </p>
+        <Button onClick={() => window.location.reload()} variant="outline">
+          Reload
+        </Button>
+      </Card>
+    </div>
+  );
+}
+
 function AppShell() {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
@@ -1307,6 +1332,7 @@ function AppShell() {
 const router = createBrowserRouter([
   {
     element: <AppShell />,
+    errorElement: <RouteErrorFallback />,
     children: [
       { path: "/reset-password", element: <ResetPassword /> },
       { path: "/confirm-email", element: <ConfirmEmail /> },

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -24,6 +24,15 @@ Sentry.init({
       return null;
     }
 
+    // Filter connection-closed AbortErrors. These fire (as an unhandled
+    // rejection with no stacktrace) when the browser tears down an in-flight
+    // request during page unload/navigation — most visibly alongside the
+    // service worker's own update check being aborted for the same reason.
+    // Not actionable: there's no app code on the other end of this rejection.
+    if (message === "AbortError: The connection was closed.") {
+      return null;
+    }
+
     // Filter WASM fetch failures on iOS/WKWebView. These are transient network
     // errors during .wasm module initialization — identifiable by "Load failed"
     // (the iOS Safari message for a failed fetch) with a WASM file in the stack.


### PR DESCRIPTION
## Summary

Reviewed recent production Sentry issues and fixed the ones that were clearly noise or clearly worth a defensive net, without touching app behavior:

- **JAVASCRIPT-REACT-2Z** (`AbortError: Failed to update a ServiceWorker ... Operation has been aborted`): the periodic `r.update()` check already skips `TypeError`/`InvalidStateError` as known-transient, non-actionable errors — it was missing `AbortError`, which fires when the update fetch gets cancelled by page unload/navigation. Added it to the existing skip-list.
- **JAVASCRIPT-REACT-30** (`AbortError: The connection was closed.`, unhandled rejection, no stacktrace): shares session replays with JAVASCRIPT-REACT-2Z, i.e. same page-unload teardown moment, surfacing through a different, uncatchable code path (no app code to attach a `.catch()` to). Added it to the Sentry `beforeSend` filter, alongside the existing browser-extension and iOS WASM-fetch filters already there for the same class of non-actionable noise.
- **JAVASCRIPT-REACT-31** (`TypeError: t.request_deck_selection is not a function`, uncaught in a `useEffect`): the router had no `errorElement`, so any uncaught render/effect error fell through to react-router's bare default fallback. Added a top-level `errorElement` with a friendly "Something went wrong / Reload" screen (styled like the existing Weapon-load-failure card). Sentry's React 19 integration already auto-captures errors caught by any error boundary via `onCaughtError`, so no manual `captureException` call was needed.

Left alone (would need larger redesigns, out of scope per the task):
- **JAVASCRIPT-REACT-32**: `RuntimeError: unreachable` — a genuine WASM OOM during language-pack deserialization on a low-memory Android tablet.
- **JAVASCRIPT-REACT-Q**: OPFS "unknown transient reason (e.g. out of memory)" on iOS Safari — Sentry's own Seer already flags this as low-actionability; it's real device memory pressure, not a code bug.

## Test plan

- [x] `cargo build` / `wasm-pack build --features local-backend` — builds clean
- [x] `pnpm tsc -b` — no type errors
- [x] `pnpm lint` — no new lint errors introduced (pre-existing unrelated errors in `weapon.tsx`, `reset-password.tsx`, `vite.config.ts` etc. are untouched by this diff)
- [ ] Manual smoke test in a browser (not done in this session)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01EuXKowRhVyhF5ZYW8rvMd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuXKowRhVyhF5ZYW8rvMd3)_