### PR TITLE
Show reload button immediately on app boot failure

### DIFF
--- a/yap-frontend/index.html
+++ b/yap-frontend/index.html
@@ -148,17 +148,34 @@
     <div id="root"></div>
     
     <script>
+      var yapBooted = false;
+
       // Show reload button after 7 seconds
       setTimeout(function() {
         var button = document.getElementById('reload-button');
-        if (button && document.getElementById('loading-screen')) {
+        if (button && !yapBooted) {
           button.classList.add('show');
         }
       }, 7000);
-      
+
+      // If the app fails to boot — e.g. the WASM module can't be fetched
+      // because of a flaky connection or an unsupported browser — surface
+      // the reload button right away instead of leaving the user staring
+      // at a spinner for 7 seconds.
+      function showReloadNow() {
+        if (yapBooted) return;
+        var loadingText = document.getElementById('loading-text');
+        if (loadingText) loadingText.textContent = 'Having trouble loading Yap.Town';
+        var button = document.getElementById('reload-button');
+        if (button) button.classList.add('show');
+      }
+      window.addEventListener('error', showReloadNow);
+      window.addEventListener('unhandledrejection', showReloadNow);
+
       // Hide loading screen when React app mounts
       // React will call this when it's ready
       window.hideLoadingScreen = function() {
+        yapBooted = true;
         var loadingScreen = document.getElementById('loading-screen');
         if (loadingScreen) {
           loadingScreen.style.display = 'none';


### PR DESCRIPTION
## Summary

Reviewed recent production Sentry issues on `yaptown`. Three of the unresolved issues turned out to be the same root cause:

- `JAVASCRIPT-REACT-30` — `AbortError: The connection was closed.` (3 events)
- `JAVASCRIPT-REACT-2J` — `TypeError: Load failed` (8 events)
- `JAVASCRIPT-REACT-2Y` — `ReferenceError: Can't find variable: WebAssembly` (4 events)

All three are uncaught errors/rejections thrown from `__vite-plugin-wasm-helper`'s `__vite__initWasm` while fetching/instantiating the app's WASM module during startup (a mid-fetch network drop, a failed fetch on a flaky connection, or `WebAssembly` simply not existing in the user's browser/webview). Since the WASM module is loaded via a static import at the top of the module graph, a failure there aborts app boot entirely with no first-party code able to catch it.

Previously, the existing loading screen (`index.html`) already had a fallback for a stuck boot: it reveals a "Reload Page" button after a flat 7-second timeout. But on an outright error/rejection there was no earlier signal — users would stare at the spinner for the full 7 seconds with no indication anything had actually failed, and no error-specific messaging.

This PR wires a `window.error`/`unhandledrejection` listener into that same loading-screen script so the reload button (and an updated "Having trouble loading" message) appears immediately when boot fails, instead of after the fixed delay. A `yapBooted` flag guards it so it's a no-op after the app has actually mounted.

Other issues reviewed (`JAVASCRIPT-REACT-31` stale-bundle method mismatch, `JAVASCRIPT-REACT-32` WASM OOM abort on a low-memory Android device, `JAVASCRIPT-REACT-33` iOS audio-device InvalidStateError, `JAVASCRIPT-REACT-2Z` aborted ServiceWorker update, `JAVASCRIPT-REACT-Q` already-handled transient OPFS error) didn't have an unambiguous, narrowly-scoped code fix — they're either already handled gracefully, environment-specific one-offs, or would require larger architectural changes (e.g. reworking WASM loading to be lazy/dynamic) that felt disproportionate to a handful of single-digit-occurrence events.

## Test plan

- [x] Validated the inline `<script>` blocks in `index.html` parse without syntax errors
- [ ] Manually verify in a browser that throwing an error before `hideLoadingScreen` runs shows the reload button immediately, and that a normal successful boot still hides the loading screen as before


---
_Generated by [Claude Code](https://claude.ai/code/session_011hbaFh8nX172JwXNxg9yic)_