### PR TITLE
Filter noisy, non-actionable Sentry errors from WASM env failures and extensions

### DIFF
--- a/generate-data/src/bin/translate_book.rs
+++ b/generate-data/src/bin/translate_book.rs
@@ -121,10 +121,10 @@ async fn main() -> anyhow::Result<()> {
     let segmenter = RemoteClient::new(RemoteConfig::default())?;
 
     for (code, lang_name, seg_hint) in LANGS {
-        if let Some(ref o) = only {
-            if o != code {
-                continue;
-            }
+        if let Some(ref o) = only
+            && o != code
+        {
+            continue;
         }
         let out_dir = PathBuf::from(format!(
             "./generate-data/data/{code}/sentence-sources/books/{series}"

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -20,16 +20,28 @@ Sentry.init({
     const message = event.exception?.values?.[0]?.value ?? "";
 
     // Filter out browser extension errors (not our code)
-    if (message.includes("runtime.sendMessage()")) {
+    if (
+      message.includes("runtime.sendMessage()") ||
+      message.includes("__firefox__.reader") ||
+      message.includes("Can't find variable: DarkReader")
+    ) {
       return null;
     }
 
-    // Filter WASM fetch failures on iOS/WKWebView. These are transient network
-    // errors during .wasm module initialization — identifiable by "Load failed"
-    // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
-    if (message === "Load failed") {
-      const frames =
-        event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+    // Filter WASM init failures caused by the environment, not our code:
+    // transient network errors fetching/compiling the .wasm module (iOS
+    // Safari's "Load failed", Chrome's "WebAssembly compilation aborted:
+    // Network error"), and embedded webviews (e.g. Twitter's in-app browser)
+    // that don't expose a WebAssembly global at all. These already surface a
+    // friendly reload prompt via the page-level listener in index.html.
+    if (message.includes("Can't find variable: WebAssembly")) {
+      return null;
+    }
+    if (
+      message.includes("Load failed") ||
+      message.includes("WebAssembly compilation aborted")
+    ) {
+      const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
       if (
         frames.some(
           (f) =>


### PR DESCRIPTION
## Summary

Reviewed the last ~30 days of unresolved production Sentry issues (`javascript-react` project) and looked for unhandled exceptions that could be fixed or refactored away without reshaping how the app works.

Most open issues turned out to already be handled correctly in the code (audio `.play()` calls are already wrapped in try/catch → no rethrow; `Weapon::load_language_pack`'s deserialization errors are already `Result`-based, not panics), or are effectively unrecoverable by design (a genuine Rust OOM abort on a low-RAM Android tablet loading a ~150MB language pack; a service-worker/wasm-bindgen version-skew crash from a single user, which would need a bigger "detect stale build, force reload" mechanism to address properly).

One clear, low-risk win: several distinct-looking issues are actually the same underlying, non-actionable noise —
- `ReferenceError: Can't find variable: WebAssembly` (embedded webviews like Twitter's in-app browser that don't expose the global)
- `TypeError: WebAssembly compilation aborted: Network error: ...` (transient network drop mid-fetch)
- `TypeError: Load failed` from the WASM helper (iOS Safari's fetch failure message)
- `TypeError: undefined is not an object (evaluating 'window.__firefox__.reader')` and `ReferenceError: Can't find variable: DarkReader` (browser extensions patching the page, not our code)

All of these already surface a friendly "having trouble loading, reload" prompt via the page-level listener in `index.html` — the only actual problem was that Sentry's `beforeSend` filter (`yap-frontend/src/instrument.ts`) only dropped one narrow variant of this (`message === "Load failed"` with a wasm frame), so the sibling messages kept cluttering the issue list as if they were new, unresolved bugs.

## Changes

- `yap-frontend/src/instrument.ts`: broadened the existing `beforeSend` filter (extending the same pattern already used for extension noise and WASM fetch failures) to also drop:
  - `Can't find variable: WebAssembly`
  - `WebAssembly compilation aborted` (same frame-based wasm-helper check as the existing `Load failed` filter)
  - Firefox reader-mode and DarkReader extension errors

No behavior change for real users — this only affects what gets reported to Sentry.

## Test plan
- [x] Read through all `.play()` call sites, `load_language_pack`, and `useWeapon`/`WeaponProvider` to confirm no other unhandled-exception fix was safely actionable here
- [ ] CI type-check/lint (this sandbox couldn't run a full `pnpm install`/`wasm-pack build` since the local WASM package wasn't pre-built)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01FDT5M16Z6kPXk7aFUHEZEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDT5M16Z6kPXk7aFUHEZEr)_