### PR TITLE
rename: check_cost_cap -> trip_cost_cap_if_exceeded

### DIFF
--- a/libraries/clean-nlp-data/src/main.rs
+++ b/libraries/clean-nlp-data/src/main.rs
@@ -921,7 +921,7 @@ fn cost_cap_tripped() -> bool {
 
 /// Evaluate the cap and trip the breaker if exceeded. Called periodically from every
 /// spending loop; cheap while under the cap.
-fn check_cost_cap(base_dir: &std::path::Path) {
+fn trip_cost_cap_if_exceeded(base_dir: &std::path::Path) {
     static CAP: LazyLock<f64> = LazyLock::new(|| {
         std::env::var("CLEAN_NLP_COST_CAP")
             .ok()
@@ -1305,7 +1305,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                             CHAT_CLIENT.cost().unwrap_or(0.0)
                         ),
                     );
-                    check_cost_cap(&status_dir);
+                    trip_cost_cap_if_exceeded(&status_dir);
                 }
 
                 (sentence, result)
@@ -1465,7 +1465,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                     pb_dc.set_message(format!("{:.2}", CHAT_CLIENT.cost().unwrap_or(0.0)));
                     pb_dc.inc(1);
                     if pb_dc.position().is_multiple_of(200) {
-                        check_cost_cap(&status_dir_dc);
+                        trip_cost_cap_if_exceeded(&status_dir_dc);
                     }
                     (sentence_text, result)
                 }
@@ -1559,7 +1559,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                             CHAT_CLIENT_MINI.cost().unwrap_or(0.0)
                         ),
                     );
-                    check_cost_cap(&status_dir2);
+                    trip_cost_cap_if_exceeded(&status_dir2);
                 }
 
                 (original_sentence, corrected_tokens, dep_result)


### PR DESCRIPTION
## Summary
- `check_cost_cap` in `libraries/clean-nlp-data/src/main.rs` reads like a pure predicate (mirroring its sibling `cost_cap_tripped()`, which really is one), but it actually mutates process-wide state: it trips a `COST_CAP_TRIPPED` atomic and writes a `status.txt` file to disk once the LLM spend cap is exceeded.
- A reader skimming call sites like `check_cost_cap(&status_dir);` would reasonably assume it's a side-effect-free query, when it's actually the function that fires the circuit breaker. The new name, `trip_cost_cap_if_exceeded`, makes the mutation explicit.
- Before: `if pb_dc.position().is_multiple_of(200) { check_cost_cap(&status_dir_dc); }` — reads as a no-op status check. After: `trip_cost_cap_if_exceeded(&status_dir_dc);` — reads as what it is: a possible state-mutating trip.

Renamed the function definition and all 3 call sites; no behavior changes.

## Test plan
- `cargo build -p clean-nlp-data` — passes
- `cargo clippy -p clean-nlp-data` — clean, no warnings
- `cargo fmt -p clean-nlp-data` — no additional changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsjFU5q4ueSwtmJ5smRHfu)_