### PR TITLE
Filter more unactionable browser/environment noise from Sentry

### DIFF
--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -24,6 +24,18 @@ Sentry.init({
       return null;
     }
 
+    // Filter out errors from crypto-wallet / reader-mode / dark-mode browser
+    // extensions injecting globals into the page (window.ethereum, DarkReader,
+    // Firefox's __firefox__ reader helper). These fire from injected scripts,
+    // not our code, and there is nothing we can do about them.
+    if (
+      message.includes("window.ethereum") ||
+      message.includes("DarkReader") ||
+      message.includes("__firefox__")
+    ) {
+      return null;
+    }
+
     // Filter WASM fetch failures on iOS/WKWebView. These are transient network
     // errors during .wasm module initialization — identifiable by "Load failed"
     // (the iOS Safari message for a failed fetch) with a WASM file in the stack.
@@ -39,6 +51,33 @@ Sentry.init({
       ) {
         return null;
       }
+    }
+
+    // Filter WASM streaming-compile failures caused by the connection
+    // dropping mid-download — same class of transient network issue as the
+    // "Load failed" case above, just surfaced with a different message.
+    if (message.startsWith("WebAssembly compilation aborted: Network error")) {
+      return null;
+    }
+
+    // Browsers/in-app webviews that don't implement WebAssembly at all can't
+    // run this app no matter what. The WASM module is imported at the top of
+    // our entry chunk (statically, across the whole codebase), so this fails
+    // before our browserSupported check in weapon.tsx ever gets a chance to
+    // run and show the "browser not supported" screen — there's no code fix
+    // short of restructuring every import in the app to be lazy.
+    if (
+      message === "Can't find variable: WebAssembly" ||
+      message === "WebAssembly is not defined"
+    ) {
+      return null;
+    }
+
+    // Environmental audio-hardware failure surfaced by Howler's internal
+    // AudioContext setup (e.g. the OS refuses to open an audio session).
+    // Not something our code triggers or can recover from.
+    if (message === "Failed to start the audio device") {
+      return null;
     }
 
     return event;


### PR DESCRIPTION
## Summary

Reviewed the last week of unresolved production errors in Sentry (5 issues, all low-volume, 1 user each). None were first-party bugs with an available code fix — they fall into the same category the codebase already filters out in `instrument.ts` (browser-extension noise, transient WASM network hiccups). This extends that existing `beforeSend` filter with a few more classes seen recently:

- **Crypto-wallet / DarkReader / Firefox-reader extension noise** — `window.ethereum.selectedAddress = undefined`, `Can't find variable: DarkReader`, `Can't find variable: __firefox__`. These come from injected extension scripts, not app code (same pattern as the existing `runtime.sendMessage()` filter).
- **WASM streaming-compile aborts from dropped connections** — `WebAssembly compilation aborted: Network error: ...`. Same class of transient network issue as the existing "Load failed" filter, just a different message.
- **`WebAssembly` undefined in restrictive in-app webviews** (e.g. an X/Twitter in-app browser) — the WASM module is statically imported at the top of the entry chunk across the whole codebase, so this fails before the `browserSupported` check in `weapon.tsx` ever runs. Fixing this for real would mean converting every WASM-touching import in the app to be lazy — out of scope for a noise-reduction pass.
- **Howler's "Failed to start the audio device"** — an `InvalidStateError` from the browser/OS refusing to open an audio session, surfaced from Howler's internal `AudioContext` setup. Not triggered by or recoverable from our code.

No behavior changes for users — this only affects what gets reported to Sentry.

## Test plan

- [x] Reviewed the diff matches the existing filter pattern/style in `instrument.ts`
- [x] Sanity-checked the edited file for syntax errors (full `tsc`/lint wasn't runnable in this environment — the WASM `pkg` dependency isn't built)
- [ ] Deploy and confirm the filtered error classes stop appearing in Sentry

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01YPzUyCLAQASUhfAJHtjmhW

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPzUyCLAQASUhfAJHtjmhW)_