### PR TITLE
Filter more non-actionable Sentry noise (WASM loading, SW updates)

### DIFF
--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -128,12 +128,14 @@ function AppMain() {
       if (r) {
         const update = () => {
           r.update().catch((e) => {
-            // Skip network-level fetch failures (TypeError) and InvalidStateError
+            // Skip network-level fetch failures (TypeError), InvalidStateError,
+            // and AbortError (an in-flight update superseded by a newer one)
             // — these are transient errors that aren't actionable bugs.
             if (
               navigator.onLine &&
               e?.name !== "InvalidStateError" &&
-              e?.name !== "TypeError"
+              e?.name !== "TypeError" &&
+              e?.name !== "AbortError"
             ) {
               Sentry.captureException(e, { tags: { "sw.online": true } });
             }

--- a/yap-frontend/src/instrument.ts
+++ b/yap-frontend/src/instrument.ts
@@ -41,6 +41,24 @@ Sentry.init({
       }
     }
 
+    // Filter WASM compilation aborts — the page was navigated away from or
+    // reloaded while the .wasm module was still streaming in. Not actionable.
+    if (message.startsWith("WebAssembly compilation aborted")) {
+      return null;
+    }
+
+    // Filter environments that lack WebAssembly entirely (some stripped-down
+    // in-app browser webviews). We can't run at all there and nothing in our
+    // code can fix that; identifiable by the wasm-helper frame that references
+    // the global WebAssembly object before our own browser-support check runs.
+    if (message === "Can't find variable: WebAssembly") {
+      const frames =
+        event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+      if (frames.some((f) => f.filename?.includes("wasm-helper"))) {
+        return null;
+      }
+    }
+
     return event;
   },
 


### PR DESCRIPTION
## Summary

Reviewed recent unresolved production Sentry issues (last 14 days, `javascript-react` project) looking for unhandled exceptions that could be simply handled or refactored away without changing app behavior.

Several issues turned out to be the same class of problem the codebase already has an established fix pattern for: transient, non-actionable errors around WASM module loading and service-worker updates, which `instrument.ts`'s `beforeSend` and `App.tsx`'s SW-update `.catch` already filter for similar cases (e.g. `"Load failed"`, `InvalidStateError`, `TypeError`).

This PR extends those same filters to also cover:
- **JAVASCRIPT-REACT-2W** — `WebAssembly compilation aborted: Network error: Response body loading was aborted`: the page was navigated away from/reloaded while the `.wasm` module was still streaming in.
- **JAVASCRIPT-REACT-2Y** — `Can't find variable: WebAssembly`: occurs in stripped-down in-app browser webviews (e.g. Twitter's in-app browser) that lack `WebAssembly` entirely, thrown from the vite wasm-helper before our own browser-support check ever runs. Nothing in our code can make WASM exist there.
- **JAVASCRIPT-REACT-2Z / JAVASCRIPT-REACT-30** — `AbortError` during service-worker `update()`: an in-flight SW update superseded by a newer one, same transient-and-not-actionable category as the existing `InvalidStateError`/`TypeError` exclusions right next to it.

Other unresolved issues were investigated but not changed because they weren't unambiguously fixable with a small change:
- `RuntimeError: unreachable` (JAVASCRIPT-REACT-32) is a genuine Rust allocation failure (OOM) on a low-memory Android tablet loading a language pack — not fixable without a larger memory-footprint change.
- `t.request_deck_selection is not a function` (JAVASCRIPT-REACT-31) is a single occurrence with no clear reproduction; looks like possible version skew between cached JS and WASM during a deploy, not a straightforward code fix.
- `InvalidStateError: Failed to start the audio device` (JAVASCRIPT-REACT-33) — all `.play()` call sites in the codebase already have proper `.catch` handling; the likely source is inside the third-party `howler` library's internals, not our code.

## Test plan
- [x] Manually reviewed the diff for correctness against the existing filter patterns in `instrument.ts` and `App.tsx`
- [ ] Confirm in Sentry after deploy that these issue types stop recurring

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01EESHK3vCRaNPp5fgt8x43Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01EESHK3vCRaNPp5fgt8x43Y)_