### PR TITLE
Reload once on stale chunk load failure for lazy chart import

### DIFF
--- a/yap-frontend/src/components/stats.tsx
+++ b/yap-frontend/src/components/stats.tsx
@@ -13,11 +13,30 @@ import { useInterval } from "react-use";
 import { NumericStats } from "./numeric-stats";
 import { Card } from "@/components/ui/card";
 
+// A tab left open across a deploy can reference a chunk hash that no longer
+// exists on the server; the server then falls back to index.html, which
+// fails to parse as JS ("'text/html' is not a valid JavaScript MIME type" /
+// "Failed to fetch dynamically imported module"). Reload once to pick up
+// the current build instead of surfacing that as an app error.
+const CHUNK_RELOAD_KEY = "chunk-load-reload";
+
 // Lazy load the chart component - only loads when needed
 const FrequencyKnowledgeChart = lazy(() =>
-  import("./FrequencyKnowledgeChart").then((module) => ({
-    default: module.FrequencyKnowledgeChart,
-  })),
+  import("./FrequencyKnowledgeChart")
+    .then((module) => {
+      sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+      return { default: module.FrequencyKnowledgeChart };
+    })
+    .catch((error) => {
+      if (!sessionStorage.getItem(CHUNK_RELOAD_KEY)) {
+        sessionStorage.setItem(CHUNK_RELOAD_KEY, "1");
+        window.location.reload();
+        // Stay pending (keep showing the Suspense fallback) until the
+        // reload takes effect, instead of flashing an error boundary.
+        return new Promise<never>(() => {});
+      }
+      throw error;
+    }),
 );
 
 interface StatsProps {


### PR DESCRIPTION
## Summary

- Sentry issue [JAVASCRIPT-REACT-36](https://yaptown.sentry.io/issues/JAVASCRIPT-REACT-36): `TypeError: 'text/html' is not a valid JavaScript MIME type.`, raised from the `FrequencyKnowledgeChart` `React.lazy()` import in `yap-frontend/src/components/stats.tsx`.
- Root cause: a tab left open across a deploy can hold a reference to a JS chunk hash that no longer exists on the server once the next deploy replaces the built assets. The dynamic `import()` for that chunk then resolves to the SPA's `index.html` fallback instead of a JS file, which fails to parse ("not a valid JavaScript MIME type" / "Failed to fetch dynamically imported module" depending on browser).
- Fix: catch that failure and reload the page once (guarded by a `sessionStorage` flag to avoid a reload loop, cleared again once a chunk load actually succeeds) instead of letting it bubble up as an unhandled app error. While waiting for the reload to take effect, the component stays suspended so the existing "Loading chart..." `Suspense` fallback keeps showing rather than flashing an error boundary.
- Scoped narrowly to the one `lazy()` call that exists in the codebase today — no changes to build/deploy behavior.

Other unresolved Sentry issues from the last 30 days were reviewed (browser-extension noise like `DarkReader`/`window.__firefox__.reader`, transient mobile network aborts, an iOS `InvalidStateError` audio issue, and a WASM OOM crash on a low-memory Android device) but none had a clear, narrow code fix that wouldn't require broader behavioral changes, so they were left alone per the "avoid massive changes" guidance.

## Test plan

- [x] Verified the edited file transforms cleanly with esbuild (syntax check) — the sandbox lacked a pre-built `yap-frontend-rs/pkg` (no `wasm-pack`/network access to fetch it), so a full `tsc -b` / `pnpm lint` pass could not be completed in this environment.
- [ ] Manually reproduce by deploying, then triggering the lazy `FrequencyKnowledgeChart` load from a tab that was open before the deploy, to confirm it reloads instead of erroring.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01R3y5CYLWPhgVLqQBSazkDk

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3y5CYLWPhgVLqQBSazkDk)_