### PR TITLE
Extract token-corrections into its own crate; canonicalize MWE proper nouns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,7 @@ dependencies = [
  "sentence-sampler",
  "serde",
  "serde_json",
+ "token-corrections",
  "tokio",
  "tysm",
  "unicode-general-category",
@@ -1898,6 +1899,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "token-corrections",
  "tokio",
  "tysm",
  "unicode-normalization",
@@ -5579,6 +5581,14 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "token-corrections"
+version = "0.1.0"
+dependencies = [
+ "language-utils",
+ "lexide",
+]
 
 [[package]]
 name = "tokenizers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "libraries/course-spot-check",
     "libraries/sentence-sampler",
     "libraries/clean-nlp-data",
+    "libraries/token-corrections",
     "libraries/enumap",
     "libraries/opensubtitles-downloader",
     "libraries/omnigram",

--- a/generate-data/Cargo.toml
+++ b/generate-data/Cargo.toml
@@ -39,6 +39,7 @@ unicode-normalization.workspace = true
 dashmap = { version = "6.2.1", features = ["serde"] }
 indicatif.workspace = true
 lexide.workspace = true
+token-corrections = { path = "../libraries/token-corrections" }
 scraper = "0.27"
 percent-encoding = "2.3.2"
 dotenvy = "0.15.7"

--- a/generate-data/src/bin/export-training-data.rs
+++ b/generate-data/src/bin/export-training-data.rs
@@ -20,6 +20,9 @@ const STORES: &[&str] = &[
     "target_language_sentences_tokenization.jsonl",
     "restricted_sentences_tokenization.jsonl",
     "target_language_multiword_terms_tokenization.jsonl",
+    // lexide's synthetic-augmentation store lives on the lexide side, not in out/;
+    // listing it here lets this bin canonicalize a copied-in big-dir too
+    "target_language_sentences_tokenization_augmented.jsonl",
 ];
 
 fn main() -> Result<()> {

--- a/generate-data/src/lib.rs
+++ b/generate-data/src/lib.rs
@@ -101,7 +101,6 @@ pub mod read_anki;
 pub mod slot_analysis;
 pub mod target_sentences;
 pub mod tatoeba;
-pub mod token_corrections;
 pub mod tokenize;
 pub mod wiktionary_conjugations;
 pub mod wiktionary_terms;

--- a/generate-data/src/nlp.rs
+++ b/generate-data/src/nlp.rs
@@ -124,7 +124,7 @@ pub fn load_canonicalized(
     }
 
     for tokens in already_processed.values_mut() {
-        crate::token_corrections::fix_tokens(language, tokens);
+        token_corrections::fix_tokens(language, tokens);
     }
 
     Ok(already_processed)
@@ -263,7 +263,7 @@ pub async fn process_sentences(
                 let json = serde_json::to_string(&tokenized)?;
                 writeln!(writer, "{json}")?;
                 // …while everything downstream sees the canonical form
-                crate::token_corrections::fix_tokens(language, &mut tokenized.tokens);
+                token_corrections::fix_tokens(language, &mut tokenized.tokens);
                 newly_processed.insert(tokenized.sentence, tokenized.tokens);
             }
             Err(failed_sentence) => {

--- a/libraries/clean-nlp-data/Cargo.toml
+++ b/libraries/clean-nlp-data/Cargo.toml
@@ -15,5 +15,6 @@ sentence-sampler = { path = "../sentence-sampler" }
 tokio.workspace = true
 futures.workspace = true
 generate-data = { path = "../../generate-data" }
+token-corrections = { path = "../token-corrections" }
 indicatif.workspace = true
 unicode-general-category = "1.1"

--- a/libraries/clean-nlp-data/src/classify.rs
+++ b/libraries/clean-nlp-data/src/classify.rs
@@ -1,9 +1,9 @@
 use crate::polysemous_words;
-use generate_data::token_corrections::{
+use language_utils::{Language, NlpAnalyzedSentence, PartOfSpeechTag};
+use token_corrections::{
     TH_PREVERBAL_AUX, TokenView, ZH_MODAL_VERBS, fix_chinese, fix_hindi, fix_japanese, fix_korean,
     fix_thai, is_hindi_aux_intervener, normalize_hindi_spelling,
 };
-use language_utils::{Language, NlpAnalyzedSentence, PartOfSpeechTag};
 use tysm::chat_completions::ChatClient;
 
 /// Check a token against the polysemous word list for a language, returning a reason if it matches.

--- a/libraries/token-corrections/Cargo.toml
+++ b/libraries/token-corrections/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "token-corrections"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+language-utils = { path = "../../language-utils" }
+lexide.workspace = true

--- a/libraries/token-corrections/src/lib.rs
+++ b/libraries/token-corrections/src/lib.rs
@@ -1,9 +1,11 @@
-//! Deterministic, idempotent per-language token corrections, shared by two pipelines:
-//! the silver tokenization data (`nlp::process_sentences`, lexide output) and
-//! clean-nlp-data's LLM cleaning (both the NLP proposal it shows the LLM and the LLM's
-//! output). Keeping one implementation here is what keeps the two datasets consistent —
-//! the corrections exist precisely because the corpus used to write the same string
-//! both ways.
+//! Deterministic, idempotent per-language token corrections — the single home for
+//! tokenization/POS/lemma policy that a model can't be trusted to apply
+//! consistently. Two consumers: generate-data's silver tokenization pipeline
+//! (`nlp::process_sentences` applies these at load time over the raw lexide
+//! stores) and clean-nlp-data's LLM cleaning (both the NLP proposal it shows the
+//! LLM and the LLM's output). Keeping one implementation here is what keeps the
+//! two datasets consistent — the corrections exist precisely because the corpus
+//! used to write the same string both ways.
 //!
 //! Everything operates through [`TokenView`], a common window onto the three token
 //! types the pipelines use: `language_utils::DocToken` (spaCy-side proposals),
@@ -1563,8 +1565,40 @@ fn ja_next_is_naru<T: TokenView>(tokens: &[T], i: usize) -> bool {
     })
 }
 
+/// Multiword proper nouns the teacher labels both ways — merged per the cleaning
+/// prompt's "unjoined multiword proper nouns should be one token". These occur
+/// almost entirely in the synthetic augmentation corpus (自由の女神 and 万里の長城
+/// were written merged/split roughly 50:50 there), where the split pieces are all
+/// real words, so only an explicit list can decide.
+const JA_MWE_MERGES: &[(&[&str], &str)] = &[
+    (&["自由", "の", "女神"], "自由の女神"),
+    (&["万里", "の", "長城"], "万里の長城"),
+];
+
 fn fix_japanese_segmentation<T: TokenView + Clone>(tokens: &mut Vec<T>) -> Vec<String> {
     let mut fixes = apply_segmentation(tokens, &JA_SEGMENTATION);
+    let mut i = 0;
+    while i < tokens.len() {
+        let matched = JA_MWE_MERGES.iter().find(|(seq, _)| {
+            i + seq.len() <= tokens.len()
+                && seq.iter().enumerate().all(|(j, piece)| {
+                    let tok = &tokens[i + j];
+                    let text = if j == 0 {
+                        tok.text().trim()
+                    } else {
+                        tok.text()
+                    };
+                    text == *piece && (j + 1 == seq.len() || tok.whitespace().is_empty())
+                })
+        });
+        if let Some((seq, whole)) = matched {
+            fixes.push(format!("Merged multiword proper noun {whole}"));
+            for _ in 1..seq.len() {
+                merge_pair(tokens, i, PartOfSpeechTag::Propn, whole);
+            }
+        }
+        i += 1;
+    }
     // Lexicalized に-adverbs the prompt lists: 本当に, 確かに — merge unless a なる
     // follows (see ja_next_is_naru). (Conditional ば after an izenkei stem needs no
     // rule here: `absorbs_suffix` already pulls it onto the predicate.)
@@ -2442,6 +2476,27 @@ mod tests {
         ];
         fix_japanese(&mut tokens);
         assert_eq!(texts(&tokens), vec!["本当", "に", "なった"]);
+    }
+
+    #[test]
+    fn japanese_mwe_merge() {
+        use lexide::DependencyRelation as D;
+        // 自由(nmod→女神) の(case→自由) 女神(nsubj→ext) は(case→女神) …
+        let mut tokens = vec![
+            ltok("自由", Noun, D::Nmod, 3),
+            ltok("の", Adp, D::Case, 1),
+            ltok("女神", Noun, D::Nsubj, 5),
+            ltok("は", Adp, D::Case, 3),
+            ltok("ある", Verb, D::Root, 0),
+        ];
+        fix_japanese(&mut tokens);
+        assert_eq!(texts(&tokens), vec!["自由の女神", "は", "ある"]);
+        // the merged PROPN keeps the head noun's external attachment
+        assert_eq!(tokens[0].pos, tag_to_lexide_pos(Propn));
+        assert_eq!(tokens[0].lemma.lemma, "自由の女神");
+        assert_eq!((tokens[0].dep, tokens[0].head), (D::Nsubj, 3));
+        assert_eq!(tokens[1].head, 1);
+        assert_eq!(tokens[2].head, 0);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #152, which shipped the deterministic token corrections as a generate-data module. Two changes on top:

## Own crate for the policy

`generate-data/src/token_corrections.rs` → `libraries/token-corrections` (git-tracked as a rename; same code, one copy). The layering now matches the names:

- **`libraries/token-corrections`** — tokenization/POS/lemma policy: the tables, fixes, and head bookkeeping. No I/O; depends only on language-utils + lexide.
- **`generate-data`** — applies the policy at load time over the raw silver stores; `export-training-data` materializes the canonical view.
- **`libraries/clean-nlp-data`** — applies the same policy around LLM output for gold.

(It can't live inside clean-nlp-data itself: clean-nlp-data genuinely depends on generate-data's `target_sentences`, and Cargo forbids package cycles.)

## MWE proper-noun merges

The Japanese table gains 自由の女神 / 万里の長城 — the augmentation teacher labels these ~50:50 and every split piece is a real word, so only an explicit list can decide. Sequence merges cascade through the pair-merge head renumbering (merged PROPN inherits the head noun's external attachment; tested). `export-training-data` also handles `*_augmented.jsonl` when pointed at a big-dir, which is how lexide's synthetic corpus was made consistent: 1,006 jpn MWE sentences all whole, kor 자유의 all split, byte-idempotent on re-run.

Validation: 8 + 129 + 31 tests pass, workspace clippy clean, canonical exports re-synced to lexide's `data/big`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiGfavXeWsNJdh2Aeyi2o6