### PR TITLE
Sync the augmentation stores into out/ so one export covers everything

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@ out/corrected_proper_nouns.jsonl filter=lfs diff=lfs merge=lfs -text
 out/*/target_language_sentences_nlp.jsonl filter=lfs diff=lfs merge=lfs -text
 out/*/target_language_sentences.jsonl filter=lfs diff=lfs merge=lfs -text
 out/*/target_language_sentences_tokenization.jsonl filter=lfs diff=lfs merge=lfs -text
+out/*/target_language_sentences_tokenization_augmented.jsonl filter=lfs diff=lfs merge=lfs -text
 out/*/target_language_multiword_terms_tokenization.jsonl filter=lfs diff=lfs merge=lfs -text
 out/cleaned_*.jsonl filter=lfs diff=lfs merge=lfs -text
 

--- a/generate-data/src/bin/export-training-data.rs
+++ b/generate-data/src/bin/export-training-data.rs
@@ -11,8 +11,10 @@
 //!
 //! Defaults: out-dir `out`, export-dir `out/training-data`. The export mirrors the
 //! `<lang>/<store>.jsonl` layout, covering every language (for languages with no
-//! correction rules the content matches the raw store), so it can serve as a
-//! drop-in `--big-dir` for data_prep.
+//! correction rules the content matches the raw store) and every store, the
+//! synthetic-augmentation files included — so `out/training-data` is the complete
+//! canonical training set, usable directly as data_prep's `--big-dir` (or synced
+//! over lexide's `data/big` in one copy).
 
 use anyhow::Result;
 
@@ -20,8 +22,8 @@ const STORES: &[&str] = &[
     "target_language_sentences_tokenization.jsonl",
     "restricted_sentences_tokenization.jsonl",
     "target_language_multiword_terms_tokenization.jsonl",
-    // lexide's synthetic-augmentation store lives on the lexide side, not in out/;
-    // listing it here lets this bin canonicalize a copied-in big-dir too
+    // lexide's synthetic-augmentation sentences, labelled by the teacher on the
+    // lexide side and synced into out/ so this one command covers every store
     "target_language_sentences_tokenization_augmented.jsonl",
 ];
 

--- a/out/deu/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/deu/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e726a8e6f233cce5f828b58adf1c665abf847c44967a054e25c42d19e58e66bc
+size 13073394

--- a/out/eng/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/eng/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d06075c28ffc5a55319cbf38903fc338d6fd435d4ae9f6da16e4d38bc5efabf7
+size 5476528

--- a/out/fra/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/fra/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78b61466e587499279cb9bebc104a8d52cce881b67c35dc2bf1eb7fd5894def1
+size 6178260

--- a/out/hin/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/hin/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:553bc9b206dad9946b527c81d85caa1cf73b1f7f077abb4faca3cd1daf31a375
+size 6080308

--- a/out/ita/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/ita/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d78d1c51d027c6535d5b13f5bb350b26d16ab81db214cc66b5d0b1b6f2069e5e
+size 5882572

--- a/out/jpn/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/jpn/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef108adb891f9077e503fb8184d0c5c466e2fc7cd798089fb5a450ed3458da9b
+size 5075439

--- a/out/kor/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/kor/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c70a65d727c0391366727570bc945e816a32e4ed61fe912b42c731174c7be0c4
+size 4730301

--- a/out/por/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/por/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0ce037a98ce106bdfe4ad241ae0eb5b17c77143afe42d6c91ca4cc597f04ac8
+size 6077063

--- a/out/rus/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/rus/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc1d2b544ebd85419d55db3172e60539bd797f4fba9106d8d070be2b7091d212
+size 5575879

--- a/out/spa/target_language_sentences_tokenization_augmented.jsonl
+++ b/out/spa/target_language_sentences_tokenization_augmented.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b48cea2fffd36c4434acc83638e342b1a93b4bd2ee9441dd2a66c373f5b65b4f
+size 6353604


### PR DESCRIPTION
Follow-up to #153. lexide's teacher-labelled synthetic sentences were the one raw store living outside `out/`, which is why refreshing training data took a second export pass pointed at lexide's big-dir. They now live in `out/<lang>/` (LFS, like the other tokenization stores), so the entire canonical training set is one command:

```
cargo run --release -p generate-data --bin export-training-data
```

`out/training-data/` then holds every store for every language — main, restricted, multiword, and augmented — ready to rsync over lexide's `data/big` in one copy (or to point data_prep's `--big-dir` at directly). Verified: single run exports all 44 stores, augmented output byte-identical to the canonicalized files already on the lexide side, and the full rsync has been done.

When lexide re-labels its augmentation corpus, the new files get copied into `out/` like any other corpus refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiGfavXeWsNJdh2Aeyi2o6