### PR TITLE
rename: allow_rate -> check_and_record_rate_limit

### DIFF
--- a/yap-mcp/src/remote.rs
+++ b/yap-mcp/src/remote.rs
@@ -209,7 +209,12 @@ impl RemoteApp {
     /// Fixed-window per-IP rate limit. Returns false when the caller should
     /// get a 429. Best-effort: the IP comes from proxy headers, so this stops
     /// floods and accidents, not a determined attacker with many addresses.
-    async fn allow_rate(&self, endpoint: &'static str, ip: String, limit: u32) -> bool {
+    async fn check_and_record_rate_limit(
+        &self,
+        endpoint: &'static str,
+        ip: String,
+        limit: u32,
+    ) -> bool {
         let mut limits = self.rate_limits.lock().await;
         limits.retain(|_, w| w.started.elapsed() < RATE_LIMIT_WINDOW);
         let window = limits.entry((endpoint, ip)).or_insert(RateWindow {
@@ -585,7 +590,10 @@ async fn register(
     headers: axum::http::HeaderMap,
     Json(req): Json<RegistrationRequest>,
 ) -> Response {
-    if !app.allow_rate("register", client_ip(&headers), 30).await {
+    if !app
+        .check_and_record_rate_limit("register", client_ip(&headers), 30)
+        .await
+    {
         return rate_limited();
     }
     if req.redirect_uris.is_empty() {
@@ -664,7 +672,10 @@ async fn authorize_page(
     headers: axum::http::HeaderMap,
     Query(params): Query<AuthorizeParams>,
 ) -> Response {
-    if !app.allow_rate("authorize", client_ip(&headers), 60).await {
+    if !app
+        .check_and_record_rate_limit("authorize", client_ip(&headers), 60)
+        .await
+    {
         return rate_limited();
     }
     if let Err(e) = validate_authorize(&app, &params) {
@@ -786,7 +797,10 @@ async fn approve(
     headers: axum::http::HeaderMap,
     Json(req): Json<ApproveRequest>,
 ) -> Response {
-    if !app.allow_rate("approve", client_ip(&headers), 30).await {
+    if !app
+        .check_and_record_rate_limit("approve", client_ip(&headers), 30)
+        .await
+    {
         return rate_limited();
     }
     let Some(pending) = app.pending_auth.lock().await.remove(&req.request_id) else {
@@ -887,7 +901,10 @@ async fn token(
     headers: axum::http::HeaderMap,
     Form(req): Form<TokenRequest>,
 ) -> Response {
-    if !app.allow_rate("token", client_ip(&headers), 120).await {
+    if !app
+        .check_and_record_rate_limit("token", client_ip(&headers), 120)
+        .await
+    {
         return rate_limited();
     }
     match req.grant_type.as_str() {


### PR DESCRIPTION
## Summary

`allow_rate` in `yap-mcp/src/remote.rs` reads as a pure predicate ("is this rate allowed?"), but every call increments a shared per-`(endpoint, ip)` counter — it consumes a rate-limit slot as a side effect, not just checks one. A reader skimming a call site like `if !app.allow_rate(...) { return 429 }` would reasonably assume the check is idempotent/side-effect-free, which is wrong: calling it twice in a row (e.g. while debugging or writing a test) silently burns two slots from the budget.

Renamed to `check_and_record_rate_limit`, which states both the check and the mutation in the name. No behavior change — pure rename across the 4 call sites in the same file (`register`, `authorize`, `approve`, `token` OAuth handlers).

**Before:**
```rust
async fn allow_rate(&self, endpoint: &'static str, ip: String, limit: u32) -> bool
```
**After:**
```rust
async fn check_and_record_rate_limit(&self, endpoint: &'static str, ip: String, limit: u32) -> bool
```

## Test plan

- [x] `cargo build -p yap-mcp` — builds cleanly
- [x] `cargo clippy -p yap-mcp` — no warnings
- [x] `cargo fmt -p yap-mcp` / `cargo fmt --check -p yap-mcp` — clean
- [x] `cargo test -p yap-mcp` — passes (no tests reference this function directly)
- [x] `grep -rn allow_rate` across the repo — no remaining references


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb6uUxyhX9ubJnwY4CvSN2)_