### PR TITLE
rename: check_cost_cap -> enforce_cost_cap

### DIFF
--- a/libraries/clean-nlp-data/src/main.rs
+++ b/libraries/clean-nlp-data/src/main.rs
@@ -920,8 +920,10 @@ fn cost_cap_tripped() -> bool {
 }
 
 /// Evaluate the cap and trip the breaker if exceeded. Called periodically from every
-/// spending loop; cheap while under the cap.
-fn check_cost_cap(base_dir: &std::path::Path) {
+/// spending loop; cheap while under the cap. Unlike a plain check, this is the call that
+/// actually flips `COST_CAP_TRIPPED` and writes the abort status — callers can't skip it
+/// on the assumption that it's read-only.
+fn enforce_cost_cap(base_dir: &std::path::Path) {
     static CAP: LazyLock<f64> = LazyLock::new(|| {
         std::env::var("CLEAN_NLP_COST_CAP")
             .ok()
@@ -1288,7 +1290,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                             CHAT_CLIENT.cost().unwrap_or(0.0)
                         ),
                     );
-                    check_cost_cap(&status_dir);
+                    enforce_cost_cap(&status_dir);
                 }
 
                 (sentence, result)
@@ -1448,7 +1450,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                     pb_dc.set_message(format!("{:.2}", CHAT_CLIENT.cost().unwrap_or(0.0)));
                     pb_dc.inc(1);
                     if pb_dc.position().is_multiple_of(200) {
-                        check_cost_cap(&status_dir_dc);
+                        enforce_cost_cap(&status_dir_dc);
                     }
                     (sentence_text, result)
                 }
@@ -1542,7 +1544,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                             CHAT_CLIENT_MINI.cost().unwrap_or(0.0)
                         ),
                     );
-                    check_cost_cap(&status_dir2);
+                    enforce_cost_cap(&status_dir2);
                 }
 
                 (original_sentence, corrected_tokens, dep_result)


### PR DESCRIPTION
## Summary

`check_cost_cap` in `libraries/clean-nlp-data/src/main.rs` reads as a pure, read-only predicate ("check" usually implies no side effects, and callers would expect a `bool` back), but it actually unconditionally mutates the process-wide `COST_CAP_TRIPPED` atomic and writes an abort status file once the LLM spend cap is exceeded — while returning `()`. A reader skimming call sites could reasonably assume it's safe to skip calling ("it's just a check") in a new spending loop, which would silently defeat the cost circuit breaker.

**Before:** `check_cost_cap(&status_dir);` — looks like a no-op inspection.
**After:** `enforce_cost_cap(&status_dir);` — makes clear this call is what actually trips the breaker and must not be skipped.

Renamed the definition, all 3 call sites, and clarified the doc comment. Scoped to a single file in a single crate (`clean-nlp-data`), no public API surface, no serialized types involved.

## Verification

```
cargo build -p clean-nlp-data
cargo clippy -p clean-nlp-data --all-targets
cargo fmt -p clean-nlp-data
```

All passed cleanly with no remaining references to the old name (`grep -rn check_cost_cap` returns nothing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFdKjQwY9Vh8MHpRMnjZdw)_