### PR TITLE
rename: check_cost_cap -> enforce_cost_cap

### DIFF
--- a/libraries/clean-nlp-data/src/main.rs
+++ b/libraries/clean-nlp-data/src/main.rs
@@ -900,7 +900,7 @@ fn cost_cap_tripped() -> bool {
 
 /// Evaluate the cap and trip the breaker if exceeded. Called periodically from every
 /// spending loop; cheap while under the cap.
-fn check_cost_cap(base_dir: &std::path::Path) {
+fn enforce_cost_cap(base_dir: &std::path::Path) {
     static CAP: LazyLock<f64> = LazyLock::new(|| {
         std::env::var("CLEAN_NLP_COST_CAP")
             .ok()
@@ -1265,7 +1265,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                             CHAT_CLIENT.cost().unwrap_or(0.0)
                         ),
                     );
-                    check_cost_cap(&status_dir);
+                    enforce_cost_cap(&status_dir);
                 }
 
                 (sentence, result)
@@ -1425,7 +1425,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                     pb_dc.set_message(format!("{:.2}", CHAT_CLIENT.cost().unwrap_or(0.0)));
                     pb_dc.inc(1);
                     if pb_dc.position().is_multiple_of(200) {
-                        check_cost_cap(&status_dir_dc);
+                        enforce_cost_cap(&status_dir_dc);
                     }
                     (sentence_text, result)
                 }
@@ -1519,7 +1519,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                             CHAT_CLIENT_MINI.cost().unwrap_or(0.0)
                         ),
                     );
-                    check_cost_cap(&status_dir2);
+                    enforce_cost_cap(&status_dir2);
                 }
 
                 (original_sentence, corrected_tokens, dep_result)


### PR DESCRIPTION
`check_cost_cap` (in `libraries/clean-nlp-data/src/main.rs`) reads like a pure, side-effect-free predicate — exactly what a caller skimming `check_cost_cap(&status_dir);` inside a spending loop would assume. In reality it mutates a process-wide `AtomicBool` circuit breaker (`COST_CAP_TRIPPED`) and writes a run-status file to disk when the LLM spend cap is exceeded, and the rest of the pipeline (`cost_cap_tripped()`, `bail_if_cost_capped()`) depends on that hidden mutation to actually stop spending.

Renamed to `enforce_cost_cap`, which signals that calling it can flip global state — consistent with its sibling helpers `cost_cap_tripped()` and `bail_if_cost_capped()` that it works alongside. Before: `check_cost_cap(&status_dir)` looked safe to call anywhere for a status readout; after: `enforce_cost_cap(&status_dir)` makes clear it's the thing that trips the breaker.

Mechanical rename only — 1 definition + 3 call sites, all within `libraries/clean-nlp-data/src/main.rs`.

**Verification:**
```
cargo build --package clean-nlp-data
cargo clippy --package clean-nlp-data
cargo fmt --package clean-nlp-data
```
All passed clean (one pre-existing, unrelated future-incompatibility warning from the `nom v2.1.0` dependency).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJadtLj9LgkkcTsvb2ieTA)_