### PR TITLE
Audio-gated challenges + beta.yap.town deploy channel

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,0 +1,117 @@
+name: Deploy Beta
+
+# Beta channel: every push to `dev` deploys the frontend bundle as a Cloudflare
+# Pages *preview* deployment of the same `yap` project (branch alias
+# `dev.yap.pages.dev`, surfaced as beta.yap.town via a CNAME in the zone).
+#
+# Deliberately lighter than Deploy Production:
+#   - no test/clippy gate (this is the play-with-it channel; main stays gated)
+#   - no Fly backend/MCP deploy — the beta frontend talks to the production
+#     backend (CORS allows any origin). A future beta backend just needs
+#     YAP_AI_BACKEND_URL set on the wasm build step below.
+#   - no dictionary KV upload and no Modal deploy — both are shared with
+#     production and a beta push must never clobber them. Dictionary pages on
+#     beta therefore render from production's KV data.
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-beta
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-deploy:
+    runs-on: big-runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          lfs: false
+
+      - name: Pull LFS rkyv files
+        run: git lfs pull --include="out/*_for_*/language_data.rkyv"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.96.0"
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-web-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-web-
+            ${{ runner.os }}-cargo-
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - name: Build WASM module
+        # To point beta at a non-production backend, add
+        # `YAP_AI_BACKEND_URL=https://...` to this line.
+        run: CARGO_PROFILE_RELEASE_LTO=true wasm-pack build --release
+        working-directory: yap-frontend-rs
+
+      - name: Generate dictionary data from language packs
+        run: cargo run --release --bin generate-dictionary-data
+
+      - name: Install frontend dependencies
+        run: pnpm install
+        working-directory: yap-frontend
+
+      - name: Install dictionary site dependencies
+        run: pnpm install
+        working-directory: static-site
+
+      - name: Build dictionary site (SSR)
+        run: pnpm build
+        working-directory: static-site
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+      - name: Build frontend (SPA)
+        run: pnpm build
+        working-directory: yap-frontend
+
+      - name: Merge SPA and dictionary into single deploy directory
+        run: |
+          DEPLOY_DIR=deploy-output
+          cp -r static-site/dist "$DEPLOY_DIR"
+          cp -r yap-frontend/dist/* "$DEPLOY_DIR/"
+          node -e "
+            const fs = require('fs');
+            const routes = JSON.parse(fs.readFileSync('$DEPLOY_DIR/_routes.json', 'utf-8'));
+            routes.include = ['/d/*', '/blog/*', '/sitemap*', '/robots.txt'];
+            fs.writeFileSync('$DEPLOY_DIR/_routes.json', JSON.stringify(routes, null, 2));
+          "
+
+      - name: Deploy to Cloudflare Pages (dev branch)
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: deploy-output
+          command: pages deploy . --project-name=yap --branch=dev

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -84,10 +84,16 @@ jobs:
         run: pnpm build
         working-directory: yap-frontend
 
+      # Deploy from a neutral directory: wrangler-action npm-installs wrangler
+      # in its working directory, and inside yap-frontend/dist npm would walk
+      # up into the pnpm-managed yap-frontend package and fail.
+      - name: Stage deploy directory
+        run: cp -r yap-frontend/dist deploy-output
+
       - name: Deploy to Cloudflare Pages (dev branch)
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: yap-frontend/dist
+          workingDirectory: deploy-output
           command: pages deploy . --project-name=yap --branch=dev

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1,8 +1,8 @@
 name: Deploy Beta
 
-# Beta channel: every push to `dev` deploys the frontend bundle as a Cloudflare
-# Pages *preview* deployment of the same `yap` project (branch alias
-# `dev.yap.pages.dev`, surfaced as beta.yap.town via a CNAME in the zone).
+# Beta channel: every push to `dev` deploys the SPA to the dedicated `yap-beta`
+# Cloudflare Pages project (production branch: dev), whose custom domain is
+# beta.yap.town.
 #
 # Deliberately lighter than Deploy Production:
 #   - no test/clippy gate (this is the play-with-it channel; main stays gated)
@@ -90,10 +90,10 @@ jobs:
       - name: Stage deploy directory
         run: cp -r yap-frontend/dist deploy-output
 
-      - name: Deploy to Cloudflare Pages (dev branch)
+      - name: Deploy to Cloudflare Pages (yap-beta project)
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: deploy-output
-          command: pages deploy . --project-name=yap --branch=dev
+          command: pages deploy . --project-name=yap-beta --branch=dev

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -9,9 +9,10 @@ name: Deploy Beta
 #   - no Fly backend/MCP deploy — the beta frontend talks to the production
 #     backend (CORS allows any origin). A future beta backend just needs
 #     YAP_AI_BACKEND_URL set on the wasm build step below.
-#   - no dictionary KV upload and no Modal deploy — both are shared with
-#     production and a beta push must never clobber them. Dictionary pages on
-#     beta therefore render from production's KV data.
+#   - no dictionary at all — no generate-dictionary-data, no Astro build, no
+#     KV upload (the KV namespace is shared with production and a beta push
+#     must never clobber it). Beta deploys the bare SPA; /d/ pages live on
+#     production only.
 
 on:
   push:
@@ -75,43 +76,18 @@ jobs:
         run: CARGO_PROFILE_RELEASE_LTO=true wasm-pack build --release
         working-directory: yap-frontend-rs
 
-      - name: Generate dictionary data from language packs
-        run: cargo run --release --bin generate-dictionary-data
-
       - name: Install frontend dependencies
         run: pnpm install
         working-directory: yap-frontend
 
-      - name: Install dictionary site dependencies
-        run: pnpm install
-        working-directory: static-site
-
-      - name: Build dictionary site (SSR)
-        run: pnpm build
-        working-directory: static-site
-        env:
-          NODE_OPTIONS: --max-old-space-size=8192
-
       - name: Build frontend (SPA)
         run: pnpm build
         working-directory: yap-frontend
-
-      - name: Merge SPA and dictionary into single deploy directory
-        run: |
-          DEPLOY_DIR=deploy-output
-          cp -r static-site/dist "$DEPLOY_DIR"
-          cp -r yap-frontend/dist/* "$DEPLOY_DIR/"
-          node -e "
-            const fs = require('fs');
-            const routes = JSON.parse(fs.readFileSync('$DEPLOY_DIR/_routes.json', 'utf-8'));
-            routes.include = ['/d/*', '/blog/*', '/sitemap*', '/robots.txt'];
-            fs.writeFileSync('$DEPLOY_DIR/_routes.json', JSON.stringify(routes, null, 2));
-          "
 
       - name: Deploy to Cloudflare Pages (dev branch)
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: deploy-output
+          workingDirectory: yap-frontend/dist
           command: pages deploy . --project-name=yap --branch=dev

--- a/yap-frontend-rs/src/audio.rs
+++ b/yap-frontend-rs/src/audio.rs
@@ -4,7 +4,7 @@ use futures::FutureExt;
 use futures::future::{LocalBoxFuture, Shared};
 use language_utils::{Compensation, TtsProvider};
 use opfs::{DirectoryHandle as _, FileHandle as _, WritableFileStream as _};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::{BTreeSet, HashMap};
 use wasm_bindgen::JsValue;
 use xxhash_rust::const_xxh3::xxh3_64 as const_xxh3;
@@ -22,6 +22,72 @@ thread_local! {
     /// one future per filename means one request, one set of bytes, one write.
     static IN_FLIGHT_FETCHES: RefCell<HashMap<String, SharedFetch>> =
         RefCell::new(HashMap::new());
+
+    /// Synchronous mirror of which clip filenames exist in the OPFS audio
+    /// directory. Challenge selection is a synchronous wasm call, but every
+    /// OPFS probe is async — this mirror is how `get_review_info` can ask
+    /// "is this clip already local?" without I/O. `None` until the first
+    /// `AudioCache::new` enumerates the directory (and forever on native,
+    /// where there is no OPFS audio cache); callers must treat unknown as
+    /// available so nothing gets hidden before the mirror loads.
+    static CACHED_CLIPS: RefCell<Option<BTreeSet<String>>> = const { RefCell::new(None) };
+
+    /// Bumped on every `CACHED_CLIPS` change. The frontend polls this cheap
+    /// counter to know when to re-run challenge selection as prefetched
+    /// clips land.
+    static CACHED_CLIPS_VERSION: Cell<u32> = const { Cell::new(0) };
+}
+
+fn cached_clips_publish(files: BTreeSet<String>) {
+    CACHED_CLIPS.with(|clips| *clips.borrow_mut() = Some(files));
+    CACHED_CLIPS_VERSION.with(|v| v.set(v.get().wrapping_add(1)));
+}
+
+fn cached_clips_insert(filename: &str) {
+    let changed = CACHED_CLIPS.with(|clips| {
+        clips
+            .borrow_mut()
+            .as_mut()
+            .is_some_and(|set| set.insert(filename.to_string()))
+    });
+    if changed {
+        CACHED_CLIPS_VERSION.with(|v| v.set(v.get().wrapping_add(1)));
+    }
+}
+
+fn cached_clips_remove(filename: &str) {
+    let changed = CACHED_CLIPS.with(|clips| {
+        clips
+            .borrow_mut()
+            .as_mut()
+            .is_some_and(|set| set.remove(filename))
+    });
+    if changed {
+        CACHED_CLIPS_VERSION.with(|v| v.set(v.get().wrapping_add(1)));
+    }
+}
+
+/// Whether the mirror has been populated at all. When false, availability is
+/// unknown and challenge selection must not hold anything back.
+pub(crate) fn cached_clips_loaded() -> bool {
+    CACHED_CLIPS.with(|clips| clips.borrow().is_some())
+}
+
+pub(crate) fn cached_clips_version() -> u32 {
+    CACHED_CLIPS_VERSION.with(|v| v.get())
+}
+
+/// Synchronously judge whether `request` can be played without a network
+/// fetch: a human recording bundled in the language pack, or a clip already
+/// in the OPFS cache. `None` means the cache mirror hasn't loaded yet, so
+/// availability is unknown.
+pub(crate) fn locally_available(request: &AudioRequest) -> Option<bool> {
+    let AudioRequest { request, provider } = request;
+    if human_audio_applies(request) && human_audio::has_clip(request.language, &request.text) {
+        return Some(true);
+    }
+    let filename = tts_cache_filename(request, provider);
+    CACHED_CLIPS.with(|clips| clips.borrow().as_ref().map(|set| set.contains(&filename)))
 }
 
 /// Result of fetching an audio clip — the bytes plus a sidecar saying who
@@ -77,6 +143,22 @@ impl AudioCache {
             .await
             .map_err(|e| JsValue::from_str(&format!("Failed to get audio directory: {e:?}")))?;
 
+        // First construction this session: enumerate the directory once to
+        // seed the synchronous mirror. Later constructions skip this — the
+        // mirror is kept current by the insert/remove hooks below.
+        if !cached_clips_loaded() {
+            use futures::StreamExt;
+            if let Ok(mut entries) = audio_dir.entries().await {
+                let mut files = BTreeSet::new();
+                while let Some(Ok((filename, _))) = entries.next().await {
+                    if filename.ends_with(".mp3") {
+                        files.insert(filename);
+                    }
+                }
+                cached_clips_publish(files);
+            }
+        }
+
         Ok(Self { audio_dir })
     }
 
@@ -111,6 +193,7 @@ impl AudioCache {
                     if let Err(e) = audio_dir.remove_entry(&cache_filename).await {
                         log::warn!("Failed to remove invalid audio cache {cache_filename}: {e:?}");
                     }
+                    cached_clips_remove(&cache_filename);
                 }
                 Err(_) => {
                     // File exists but couldn't read
@@ -120,6 +203,7 @@ impl AudioCache {
                             "Failed to remove unreadable audio cache {cache_filename}: {e:?}"
                         );
                     }
+                    cached_clips_remove(&cache_filename);
                 }
             }
         }
@@ -137,6 +221,7 @@ impl AudioCache {
         if let Err(e) = audio_dir.remove_entry(&cache_filename).await {
             log::warn!("Failed to remove audio cache {cache_filename}: {e:?}");
         }
+        cached_clips_remove(&cache_filename);
 
         Ok(())
     }
@@ -159,6 +244,7 @@ impl AudioCache {
         {
             let _ = writable.write_at_cursor_pos(&bytes).await;
             let _ = writable.close().await;
+            cached_clips_insert(&cache_filename);
         }
 
         self.touch_index(&cache_filename).await;
@@ -375,6 +461,11 @@ impl AudioCache {
         if index_changed {
             self.write_index(&index).await;
         }
+
+        // The enumeration above is ground truth; republish it so the mirror
+        // recovers from any drift (e.g. an insert hook missed by an
+        // interrupted write).
+        cached_clips_publish(present_files);
 
         Ok(())
     }

--- a/yap-frontend-rs/src/human_audio.rs
+++ b/yap-frontend-rs/src/human_audio.rs
@@ -35,6 +35,19 @@ pub struct HumanAudio {
     pub compensation: Compensation,
 }
 
+/// Whether any voice actor has a recording for `(language, text)` — the
+/// existence half of `lookup`, without advancing the round-robin counter or
+/// cloning clip bytes.
+pub fn has_clip(language: Language, text: &str) -> bool {
+    let registry = REGISTRY.lock().expect("human audio registry poisoned");
+    let Some(pack) = registry.packs.get(&language).and_then(Weak::upgrade) else {
+        return false;
+    };
+    pack.human_audio
+        .values()
+        .any(|clips| clips.contains_key(text))
+}
+
 /// Return a human-recorded clip for `(language, text)` if any voice actor
 /// has a recording for that exact phrase. When multiple actors have a recording,
 /// rotates round-robin across successive calls (actors sorted by name).

--- a/yap-frontend-rs/src/language_pack.rs
+++ b/yap-frontend-rs/src/language_pack.rs
@@ -486,11 +486,7 @@ async fn download_language_data_chunk(
         };
         async move {
             let client = fetch_happen::Client;
-            let url = if cfg!(feature = "local-backend") {
-                "http://localhost:21516"
-            } else {
-                "https://yap-ai-backend.fly.dev"
-            };
+            let url = crate::utils::ai_server_url();
             let full_url = format!("{url}{path}");
             client.post(&full_url).json(&request)?.send().await
         }

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -95,6 +95,15 @@ pub fn get_ai_server_url() -> String {
     utils::ai_server_url().to_string()
 }
 
+/// Version counter of the local audio-clip mirror; changes whenever a clip
+/// is cached or evicted. The frontend polls this to re-run challenge
+/// selection as the background prefetcher lands clips (which can un-hide
+/// audio challenges that were held back as not-yet-playable).
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub fn get_audio_cache_version() -> u32 {
+    audio::cached_clips_version()
+}
+
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub fn get_showcase_data() -> Vec<language_utils::CourseShowcase> {
     static SHOWCASE_JSONS: &[&str] = &[
@@ -2472,7 +2481,14 @@ impl Deck {
         banned_challenge_types: Vec<ChallengeRequirements>,
         timestamp_ms: f64,
     ) -> ReviewInfo {
-        self.get_review_info_impl(banned_challenge_types, timestamp_ms, false)
+        let mut review_info =
+            self.get_review_info_impl(banned_challenge_types, timestamp_ms, false);
+        // Only the app-facing view holds back audio-pending cards. The
+        // prefetch simulation goes through `get_review_info_impl` directly
+        // and must keep seeing them — it's the thing that downloads their
+        // audio, so hiding them there would leave them hidden forever.
+        review_info.hold_back_audio_pending(self);
+        review_info
     }
 
     /// Like `get_review_info`, but treats locked cards as due. Used by the
@@ -2541,6 +2557,7 @@ impl Deck {
             due_cards,
             due_but_banned_cards,
             due_but_locked_cards,
+            due_but_audio_pending_cards: vec![],
             future_cards,
         }
     }
@@ -2569,7 +2586,10 @@ impl Deck {
             return None;
         }
 
-        let review_info = self.get_review_info(banned_challenge_types, timestamp_ms);
+        // Unfiltered view: a card whose audio merely hasn't downloaded yet is
+        // still one of today's most-due cards, and must land in the lockup's
+        // keep-list rather than get locked away for the day.
+        let review_info = self.get_review_info_impl(banned_challenge_types, timestamp_ms, false);
         if review_info.due_cards.len() <= REVIEW_LOCKUP_TRIGGER {
             return None;
         }
@@ -4271,6 +4291,10 @@ pub struct ReviewInfo {
     due_cards: Vec<CardIndicator<SpurGram, Spur>>,
     due_but_banned_cards: Vec<CardIndicator<SpurGram, Spur>>,
     due_but_locked_cards: Vec<CardIndicator<SpurGram, Spur>>,
+    /// Due cards held back because their challenge needs audio that isn't in
+    /// the local cache yet (see `hold_back_audio_pending`). They reappear in
+    /// `due_cards` once the background prefetcher lands their clips.
+    due_but_audio_pending_cards: Vec<CardIndicator<SpurGram, Spur>>,
     future_cards: Vec<CardIndicator<SpurGram, Spur>>,
 }
 
@@ -4341,6 +4365,44 @@ pub enum ChallengeRequirements {
 }
 
 impl ReviewInfo {
+    /// Move cards from the front of `due_cards` into
+    /// `due_but_audio_pending_cards` when their challenge needs audio the
+    /// device doesn't have locally yet — the app should only offer a
+    /// challenge the user can actually complete right now.
+    ///
+    /// Only the front of the queue is examined, stopping at the first card
+    /// that is playable (or isn't an audio challenge): generating a challenge
+    /// is expensive, and correctness only requires that the challenge the app
+    /// will actually show — `due_cards[0]` — is playable. When the audio
+    /// cache mirror hasn't loaded (first moments of a session, native
+    /// builds), availability is unknown and nothing is held back.
+    fn hold_back_audio_pending(&mut self, deck: &Deck) {
+        if !audio::cached_clips_loaded() {
+            return;
+        }
+        while let Some(&card) = self.due_cards.first() {
+            let needs_audio = matches!(
+                card.card_type().challenge_type(),
+                ChallengeRequirements::Listening | ChallengeRequirements::Speaking
+            );
+            if !needs_audio {
+                break;
+            }
+            let Some(challenge) = self.get_challenge_for_card(deck, card) else {
+                break;
+            };
+            let missing_audio = challenge
+                .audio_requests()
+                .iter()
+                .any(|request| audio::locally_available(request) == Some(false));
+            if !missing_audio {
+                break;
+            }
+            self.due_cards.remove(0);
+            self.due_but_audio_pending_cards.push(card);
+        }
+    }
+
     // TODO: make this more resillient by separating it into a function that fallibly a real challenge and a function that tries to call the previous and returns a flashcard if it fails
     pub fn get_challenge_for_card(
         &self,
@@ -4390,6 +4452,11 @@ impl ReviewInfo {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn due_but_locked_count(&self) -> usize {
         self.due_but_locked_cards.len()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn due_but_audio_pending_count(&self) -> usize {
+        self.due_but_audio_pending_cards.len()
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]

--- a/yap-frontend-rs/src/lib.rs
+++ b/yap-frontend-rs/src/lib.rs
@@ -205,6 +205,19 @@ impl Weapon {
             }
         });
 
+        // Seed the audio-cache mirror before any deck API is reachable, so
+        // even the first get_review_info of a session can hold back audio
+        // challenges whose clips aren't local (otherwise the first challenge
+        // of a cold start races the directory enumeration and can slip
+        // through unplayable). Failure just leaves the mirror unloaded,
+        // which degrades to not holding anything back. Wasm-only: on native
+        // (yap-mcp) there is no audio cache and the mirror must stay
+        // unloaded so nothing is ever filtered there.
+        #[cfg(target_arch = "wasm32")]
+        if let Err(e) = audio::AudioCache::new().await {
+            log::warn!("Failed to seed audio cache mirror: {e:?}");
+        }
+
         Ok(Self {
             store: RefCell::new(events),
             user_id,

--- a/yap-frontend-rs/src/utils.rs
+++ b/yap-frontend-rs/src/utils.rs
@@ -174,12 +174,14 @@ pub(crate) async fn get_or_create_device_id(
     }
 }
 
-/// Base URL of the yap AI backend (compile-time switch for local dev).
+/// Base URL of the yap AI backend. The `local-backend` feature wins (local
+/// dev), then the `YAP_AI_BACKEND_URL` compile-time env var (beta/staging
+/// builds pointing at a non-production backend), then production.
 pub fn ai_server_url() -> &'static str {
     if cfg!(feature = "local-backend") {
         "http://localhost:21516"
     } else {
-        "https://yap-ai-backend.fly.dev"
+        option_env!("YAP_AI_BACKEND_URL").unwrap_or("https://yap-ai-backend.fly.dev")
     }
 }
 

--- a/yap-frontend/src/App.tsx
+++ b/yap-frontend/src/App.tsx
@@ -35,6 +35,7 @@ import {
   type /* comes from TranscriptionChallenge */ PartGraded,
   type Rating,
   get_pronunciation_connector,
+  get_audio_cache_version,
 } from "../../yap-frontend-rs/pkg";
 import { Button } from "@/components/ui/button.tsx";
 import { Progress } from "@/components/ui/progress.tsx";
@@ -901,6 +902,13 @@ function Review({
     ChallengeRequirements[]
   >(() => computeBannedChallengeTypes());
 
+  // Challenges whose audio isn't cached yet are held back by
+  // get_review_info; poll the cache version so they surface as soon as the
+  // background prefetcher lands their clips. Same-value updates bail out of
+  // the state change, so the steady state costs no re-renders.
+  const [audioCacheVersion, setAudioCacheVersion] = useState(0);
+  useInterval(() => setAudioCacheVersion(get_audio_cache_version()), 2000);
+
   const { reviewInfo, lockupOffer } = useMemo(() => {
     const now = Date.now();
     return {
@@ -909,8 +917,9 @@ function Review({
       // most-due cards active and set the rest aside
       lockupOffer: deck.get_lockup_offer(bannedChallengeTypes, now),
     };
-    // cardsBecameDue is intentionally included to trigger recalculation when cards become due
-  }, [deck, bannedChallengeTypes, cardsBecameDue]);
+    // cardsBecameDue and audioCacheVersion are intentionally included to
+    // trigger recalculation when cards become due / audio finishes caching
+  }, [deck, bannedChallengeTypes, cardsBecameDue, audioCacheVersion]);
 
   useInterval(
     () => setCardsBecameDue((cardsBecameDue) => cardsBecameDue + 1),
@@ -1207,6 +1216,7 @@ function Review({
             targetLanguage={targetLanguage}
             deck={deck}
             bannedChallengeTypes={bannedChallengeTypes}
+            audioPendingCount={reviewInfo.due_but_audio_pending_count}
             userInfo={userInfo}
             sentenceList={sentenceList}
             setSentenceList={setSentenceList}

--- a/yap-frontend/src/components/no-cards-ready.tsx
+++ b/yap-frontend/src/components/no-cards-ready.tsx
@@ -22,6 +22,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Headphones,
+  LoaderCircle,
   Sparkles,
 } from "lucide-react";
 import { Card } from "@/components/ui/card";
@@ -53,6 +54,9 @@ interface NoCardsReadyProps {
   targetLanguage: Language;
   deck: Deck;
   bannedChallengeTypes: ChallengeRequirements[];
+  /// Due cards held back because their audio hasn't downloaded yet — they'll
+  /// appear as challenges once the background prefetcher catches up.
+  audioPendingCount: number;
   userInfo: UserInfo | undefined;
   sentenceList: SentenceList;
   setSentenceList: (sentenceList: SentenceList) => void;
@@ -67,6 +71,7 @@ export const NoCardsReady = memo(function NoCardsReady({
   targetLanguage,
   deck,
   bannedChallengeTypes,
+  audioPendingCount,
   userInfo,
   sentenceList,
   setSentenceList,
@@ -309,6 +314,28 @@ export const NoCardsReady = memo(function NoCardsReady({
         return null;
     }
   })();
+
+  // Due challenges exist but their audio hasn't downloaded yet (the review
+  // screen only offers challenges the user can actually complete). This
+  // normally resolves within seconds as the background prefetcher lands
+  // clips — but it can persist offline, which is why it explains itself
+  // rather than showing a bare spinner.
+  if (audioPendingCount > 0) {
+    return (
+      <div className="flex flex-col flex-1 gap-4 pt-4">
+        <div className="flex flex-col gap-2 text-center">
+          <p className="text-2xl font-bold">Just a moment…</p>
+          <p className="text-muted-foreground">
+            Downloading the audio for your next challenge.
+          </p>
+        </div>
+        <div className="flex justify-center py-4">
+          <LoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+        <WeekProgressStrip deck={deck} className="mt-auto mb-2" />
+      </div>
+    );
+  }
 
   // While cards remain set aside in lockup, the whole add-cards area is
   // replaced by releasing the next batch. Never says "all caught up" — that's


### PR DESCRIPTION
## Audio-gated challenges

Only offer audio challenges (Listening/Speaking cards) whose audio is already playable locally, so the user is never shown a challenge they can't complete.

- `audio.rs` keeps a synchronous thread-local mirror (`CACHED_CLIPS`) of which clips exist in the OPFS audio directory, seeded by directory enumeration and maintained by every cache/evict/cleanup path. This lets the synchronous `get_review_info` ask "is this clip local?" without async OPFS I/O.
- `ReviewInfo::hold_back_audio_pending` skims audio challenges with missing clips off the front of `due_cards` into a new `due_but_audio_pending` bucket, stopping at the first playable card (challenge generation is expensive; only `due_cards[0]` must be playable). Human-recorded pack audio counts as always available.
- The prefetch simulation and lockup offers deliberately use the unfiltered view: the prefetcher is what downloads the missing audio (filtering it would hide cards forever), and lockup must keep a slow-to-download card in its keep-list rather than lock it away.
- The frontend polls `get_audio_cache_version()` (2s) to surface held-back cards as clips land; `NoCardsReady` shows a "Just a moment… downloading audio" state when everything due is waiting.
- `Weapon::create` seeds the mirror before any deck API is reachable (wasm-only), closing the cold-start window. Native (yap-mcp) never seeds, so nothing is ever filtered there. Unknown availability always fails open.

## beta.yap.town deploy channel

- New `Deploy Beta` workflow: every push to `dev` builds the bare SPA (no dictionary/Astro/KV) and deploys it to the dedicated `yap-beta` Pages project, whose custom domain is beta.yap.town. No test gate, no Fly/MCP/Modal deploys, nothing shared with prod is touched.
- The wasm backend URL gains a compile-time `YAP_AI_BACKEND_URL` override (`local-backend` feature still wins; prod default unchanged) for a future beta backend; beta currently talks to the production backend.

Verified: workspace + wasm clippy clean, all yap-frontend-rs tests pass, tsc + production Vite build succeed, beta channel deployed end-to-end and serving at beta.yap.town.

🤖 Generated with [Claude Code](https://claude.com/claude-code)