### PR TITLE
rename: check_cost_cap -> enforce_cost_cap

### DIFF
--- a/libraries/clean-nlp-data/src/main.rs
+++ b/libraries/clean-nlp-data/src/main.rs
@@ -900,7 +900,7 @@ fn cost_cap_tripped() -> bool {
 
 /// Evaluate the cap and trip the breaker if exceeded. Called periodically from every
 /// spending loop; cheap while under the cap.
-fn check_cost_cap(base_dir: &std::path::Path) {
+fn enforce_cost_cap(base_dir: &std::path::Path) {
     static CAP: LazyLock<f64> = LazyLock::new(|| {
         std::env::var("CLEAN_NLP_COST_CAP")
             .ok()
@@ -1265,7 +1265,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                             CHAT_CLIENT.cost().unwrap_or(0.0)
                         ),
                     );
-                    check_cost_cap(&status_dir);
+                    enforce_cost_cap(&status_dir);
                 }
 
                 (sentence, result)
@@ -1425,7 +1425,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                     pb_dc.set_message(format!("{:.2}", CHAT_CLIENT.cost().unwrap_or(0.0)));
                     pb_dc.inc(1);
                     if pb_dc.position().is_multiple_of(200) {
-                        check_cost_cap(&status_dir_dc);
+                        enforce_cost_cap(&status_dir_dc);
                     }
                     (sentence_text, result)
                 }
@@ -1519,7 +1519,7 @@ async fn clean_language_with_llm(language: Language) -> anyhow::Result<()> {
                             CHAT_CLIENT_MINI.cost().unwrap_or(0.0)
                         ),
                     );
-                    check_cost_cap(&status_dir2);
+                    enforce_cost_cap(&status_dir2);
                 }
 
                 (original_sentence, corrected_tokens, dep_result)


### PR DESCRIPTION
## Summary
`check_cost_cap` (in `libraries/clean-nlp-data/src/main.rs`) reads as a pure/read-only predicate, but it actually mutates a process-wide `AtomicBool` circuit breaker and writes `status.txt` to disk once the LLM spend cap is exceeded — a `check_`-named function with side effects a caller wouldn't expect from the name alone. Renamed to `enforce_cost_cap`, which conveys that calling it can change shared state, not just read it.

Before: `check_cost_cap(&status_dir);` — looks safe to call speculatively/repeatedly.
After: `enforce_cost_cap(&status_dir);` — signals it may trip the breaker and write status as a side effect.

Pure rename, no behavior change. Updated the definition and all 3 call sites.

## Test plan
- `cargo build -p clean-nlp-data` — passes
- `cargo clippy -p clean-nlp-data --all-targets` — clean
- `cargo fmt -p clean-nlp-data` — no formatting changes beyond the rename


---
_Generated by [Claude Code](https://claude.ai/code/session_016nVKZEdTmqdQCKo9Z5ZBTm)_